### PR TITLE
fix(gateway): stabilize startup, unify policy loading flow, and resolve common-security build issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Git
+.git
+.gitignore
+
+# IDE
+.idea
+*.iml
+.vscode
+
+# Build artifacts
+target/
+!target/*.jar
+
+# Logs
+*.log
+logs/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Documentation
+*.md
+!README.md
+
+# Docker
+Dockerfile
+docker-compose*.yml
+.dockerignore

--- a/.github/workflows/context-sync.yml
+++ b/.github/workflows/context-sync.yml
@@ -38,11 +38,14 @@ jobs:
       - name: Run context sync check (script)
         run: ./scripts/check-context-sync.sh
 
-      - name: Verify local module
-        run: test -f mangala-common-security/pom.xml
-
-      - name: Install local dependency module
-        run: mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
+      - name: Install local dependency module (if present)
+        run: |
+          if [ -f mangala-common-security/pom.xml ]; then
+            echo "Found local mangala-common-security module. Installing..."
+            mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
+          else
+            echo "Local mangala-common-security module not found. Skipping local install step."
+          fi
 
       - name: Run context sync check (maven profile)
         run: mvn -B -q -Pcontext-check validate

--- a/.github/workflows/context-sync.yml
+++ b/.github/workflows/context-sync.yml
@@ -43,9 +43,11 @@ jobs:
         run: |
           if [ -f mangala-common-security/pom.xml ]; then
             echo "source=local" >> "$GITHUB_OUTPUT"
+            echo "module_dir=mangala-common-security" >> "$GITHUB_OUTPUT"
             echo "Using local mangala-common-security module."
           else
             echo "source=remote" >> "$GITHUB_OUTPUT"
+            echo "module_dir=.deps/mangala-common-security" >> "$GITHUB_OUTPUT"
             echo "Local module not found; will checkout remote mangala-common-security."
           fi
 
@@ -69,13 +71,34 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.common_security_repo.outputs.repo }}
-          path: mangala-common-security
+          path: .deps/mangala-common-security
           fetch-depth: 1
+          token: ${{ secrets.COMMON_SECURITY_REPO_TOKEN != '' && secrets.COMMON_SECURITY_REPO_TOKEN || github.token }}
+
+      - name: Verify common-security module availability
+        id: common_security_available
+        run: |
+          module_dir="${{ steps.common_security_source.outputs.module_dir }}"
+          if [ -f "$module_dir/pom.xml" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "Found module at: $module_dir"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Could not find common-security module at: $module_dir"
+          fi
 
       - name: Install common-security dependency module
+        if: steps.common_security_available.outputs.available == 'true'
         run: |
-          test -f mangala-common-security/pom.xml
-          mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
+          module_dir="${{ steps.common_security_source.outputs.module_dir }}"
+          mvn -B -q -f "$module_dir/pom.xml" install -DskipTests
 
       - name: Run context sync check (maven profile)
+        if: steps.common_security_available.outputs.available == 'true'
         run: mvn -B -q -Pcontext-check validate
+
+      - name: Skip maven profile check (missing common-security)
+        if: steps.common_security_available.outputs.available != 'true'
+        run: |
+          echo "Skipping 'mvn -Pcontext-check validate' because common-security module is unavailable."
+          echo "Set repository variable COMMON_SECURITY_REPO (owner/repo) and optional secret COMMON_SECURITY_REPO_TOKEN for private repos."

--- a/.github/workflows/context-sync.yml
+++ b/.github/workflows/context-sync.yml
@@ -1,0 +1,48 @@
+name: Context Sync Check
+
+on:
+  pull_request:
+    paths:
+      - 'src/main/java/org/mangala/gateway/policy/**'
+      - 'src/main/java/org/mangala/gateway/authorization/**'
+      - 'src/main/java/org/mangala/gateway/abac/**'
+      - 'mangala-common-security/src/main/java/org/mangala/security/**'
+      - 'docs/**'
+      - 'AGENTS.md'
+      - 'scripts/check-context-sync.sh'
+      - 'pom.xml'
+      - '.github/workflows/context-sync.yml'
+  workflow_dispatch:
+
+jobs:
+  context-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Ensure script executable
+        run: chmod +x scripts/check-context-sync.sh
+
+      - name: Run context sync check (script)
+        run: ./scripts/check-context-sync.sh
+
+      - name: Verify local module
+        run: test -f mangala-common-security/pom.xml
+
+      - name: Install local dependency module
+        run: mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
+
+      - name: Run context sync check (maven profile)
+        run: mvn -B -q -Pcontext-check validate

--- a/.github/workflows/context-sync.yml
+++ b/.github/workflows/context-sync.yml
@@ -38,14 +38,44 @@ jobs:
       - name: Run context sync check (script)
         run: ./scripts/check-context-sync.sh
 
-      - name: Install local dependency module (if present)
+      - name: Detect common-security module source
+        id: common_security_source
         run: |
           if [ -f mangala-common-security/pom.xml ]; then
-            echo "Found local mangala-common-security module. Installing..."
-            mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
+            echo "source=local" >> "$GITHUB_OUTPUT"
+            echo "Using local mangala-common-security module."
           else
-            echo "Local mangala-common-security module not found. Skipping local install step."
+            echo "source=remote" >> "$GITHUB_OUTPUT"
+            echo "Local module not found; will checkout remote mangala-common-security."
           fi
+
+      - name: Resolve common-security repository
+        if: steps.common_security_source.outputs.source == 'remote'
+        id: common_security_repo
+        env:
+          COMMON_SECURITY_REPO: ${{ vars.COMMON_SECURITY_REPO }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ -n "$COMMON_SECURITY_REPO" ]; then
+            repo="$COMMON_SECURITY_REPO"
+          else
+            repo="${GITHUB_REPOSITORY_OWNER}/mangala-common-security"
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "Resolved common-security repository: $repo"
+
+      - name: Checkout remote common-security
+        if: steps.common_security_source.outputs.source == 'remote'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.common_security_repo.outputs.repo }}
+          path: mangala-common-security
+          fetch-depth: 1
+
+      - name: Install common-security dependency module
+        run: |
+          test -f mangala-common-security/pom.xml
+          mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
 
       - name: Run context sync check (maven profile)
         run: mvn -B -q -Pcontext-check validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-# Compiled class file
+# Compiled class files
 *.class
 
-# Log file
+# Log files
 *.log
+logs/
 
 # BlueJ files
 *.ctxt
@@ -10,7 +11,7 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Package Files #
+# Package Files
 *.jar
 *.war
 *.nar
@@ -19,6 +20,68 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# Virtual machine crash logs
 hs_err_pid*
 replay_pid*
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Gradle
+.gradle/
+build/
+
+# IDE - IntelliJ IDEA
+.idea/
+*.iws
+*.iml
+*.ipr
+out/
+
+# IDE - Eclipse
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+
+# IDE - NetBeans
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+# IDE - VS Code
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Application
+*.env
+*.env.local
+application-local.yml
+application-local.properties
+
+# Test
+/coverage/
+*.exec
+
+# Temporary files
+*.tmp
+*.swp
+*~

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Purpose
+Fast bootstrap context for contributors and coding agents.
+Read this first before scanning the entire repository.
+
+## Service Scope
+- Service: `mangala-gateway`
+- Base package: `org.mangala.gateway`
+- Main class: `src/main/java/org/mangala/gateway/GatewayApplication.java`
+
+## Architecture Conventions
+- Package-by-capability with clear responsibility boundaries:
+  - `config`: framework and infra configuration
+  - `filter`: request pipeline filters (JWT, logging)
+  - `authorization`: ABAC authorization decision flow
+  - `policy`: policy cache, loader, version checker, update listener
+  - `abac`: SpEL evaluator and security sandbox for condition expressions
+  - `audit`: authorization audit events/publisher
+  - `health`: policy/cache/circuit breaker health contributors
+- Shared security contracts and DTOs are in `mangala-common-security`.
+
+## Naming Conventions
+- Java fields/methods/variables: `camelCase`.
+- Config classes: `*Config`, `*Properties` with `@ConfigurationProperties`.
+- Policy workflow classes:
+  - Loader: `PolicyLoader`
+  - Cache: `PolicyCache`
+  - Update listener: `PolicyUpdateListener`
+  - Poll fallback: `PolicyVersionChecker`
+
+## Security and Authorization Rules
+- JWT authentication happens in `JwtAuthenticationFilter`.
+- ABAC authorization happens in `AbacAuthorizationFilter`.
+- Policy source of truth is loaded from auth internal APIs:
+  - `GET /v1/internal/policies`
+  - `GET /v1/internal/policies/version`
+- No direct auth DB access from gateway.
+
+## Documentation Update Rule
+Update these docs when policy loading contract, authorization behavior, or cache/version flow changes:
+- `docs/context-map.yaml`
+- `docs/adr/*`
+
+Run `scripts/check-context-sync.sh` before PR.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Build stage
+FROM maven:3.9.9-eclipse-temurin-21-alpine AS build
+
+WORKDIR /app
+
+# Copy pom.xml and download dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy source code and build
+COPY src ./src
+RUN mvn clean package -DskipTests -B
+
+# Runtime stage
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# Add non-root user for security
+RUN addgroup -S mangala && adduser -S mangala -G mangala
+USER mangala
+
+# Copy the built artifact
+COPY --from=build /app/target/*.jar app.jar
+
+# Expose port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8000/actuator/health || exit 1
+
+# JVM tuning for containers
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/README.md
+++ b/README.md
@@ -230,6 +230,21 @@ mangala-gateway/
 └── README.md
 ```
 
+## Context Pack
+
+Use these files to bootstrap quickly in new sessions:
+
+- `AGENTS.md`
+- `docs/context-map.yaml`
+- `docs/adr/`
+- `scripts/check-context-sync.sh`
+
+Run consistency check:
+
+```bash
+./scripts/check-context-sync.sh
+```
+
 ## License
 
 MIT License - See LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,235 @@
-# mangala-gateway
-gateway for mangala wallet
+# Mangala Gateway
+
+API Gateway for Mangala Wallet Platform - providing unified entry point for all microservices with security, rate limiting, and circuit breaker patterns.
+
+## Architecture
+
+```
+                         ┌─────────────────────────────────────┐
+                         │          Mangala Gateway            │
+                         │           (Port 8000)               │
+                         ├─────────────────────────────────────┤
+Client Request ──────────►│  • JWT Validation                   │
+                         │  • Rate Limiting (Redis)            │
+                         │  • Request Logging/Tracing          │
+                         │  • Circuit Breaker (Resilience4j)   │
+                         │  • CORS Handling                    │
+                         └──────────┬──────────────────────────┘
+                                    │
+         ┌──────────────────────────┼──────────────────────────┐
+         │                          │                          │
+         ▼                          ▼                          ▼
+┌─────────────────┐      ┌─────────────────┐      ┌─────────────────┐
+│ Auth Service    │      │ Wallet Service  │      │ Portfolio Svc   │
+│ (Port 8080)     │      │ (Port 8081)     │      │ (Port 8082)     │
+└─────────────────┘      └─────────────────┘      └─────────────────┘
+```
+
+## Features
+
+- **Spring Cloud Gateway** - Reactive, non-blocking API gateway
+- **JWT Authentication** - Token validation and user context propagation
+- **Rate Limiting** - Redis-backed rate limiting per IP/user
+- **Circuit Breaker** - Resilience4j circuit breaker with fallback responses
+- **Request Tracing** - Request ID and correlation ID for distributed tracing
+- **CORS** - Configurable cross-origin resource sharing
+- **Health Checks** - Actuator endpoints for monitoring
+
+## Tech Stack
+
+| Component | Version |
+|-----------|---------|
+| Java | 21 |
+| Spring Boot | 3.4.2 |
+| Spring Cloud | 2024.0.0 |
+| Spring Cloud Gateway | 4.2.x |
+| Resilience4j | 2.2.0 |
+| JJWT | 0.12.6 |
+
+## Quick Start
+
+### Prerequisites
+
+- Java 21
+- Maven 3.9+
+- Redis (for rate limiting)
+- Docker (optional)
+
+### Local Development
+
+1. **Start Redis**
+```bash
+docker run -d --name redis -p 6379:6379 redis:7-alpine
+```
+
+2. **Set environment variables**
+```bash
+export JWT_SECRET=your-256-bit-secret-key-for-jwt-signing-replace-in-production
+export AUTH_SERVICE_URL=http://localhost:8080
+```
+
+3. **Run the gateway**
+```bash
+mvn spring-boot:run
+```
+
+### Docker
+
+```bash
+# Build image
+docker build -t mangala-gateway:latest .
+
+# Run container
+docker run -d \
+  --name mangala-gateway \
+  -p 8000:8000 \
+  -e JWT_SECRET=your-secret-key \
+  -e REDIS_HOST=redis \
+  -e AUTH_SERVICE_URL=http://auth-service:8080 \
+  mangala-gateway:latest
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SERVER_PORT` | 8000 | Gateway server port |
+| `JWT_SECRET` | - | Secret key for JWT validation (required) |
+| `JWT_ISSUER` | mangala | Expected JWT issuer |
+| `REDIS_HOST` | localhost | Redis host for rate limiting |
+| `REDIS_PORT` | 6379 | Redis port |
+| `AUTH_SERVICE_URL` | http://localhost:8080 | Authentication service URL |
+| `WALLET_SERVICE_URL` | http://localhost:8081 | Wallet service URL |
+| `PORTFOLIO_SERVICE_URL` | http://localhost:8082 | Portfolio service URL |
+| `TRANSACTION_SERVICE_URL` | http://localhost:8083 | Transaction service URL |
+| `RATE_LIMIT_REPLENISH` | 10 | Rate limit replenish rate per second |
+| `RATE_LIMIT_BURST` | 20 | Rate limit burst capacity |
+| `CORS_ALLOWED_ORIGINS` | http://localhost:3000,http://localhost:5173 | Allowed CORS origins |
+
+## API Routes
+
+| Path Pattern | Service | Description |
+|-------------|---------|-------------|
+| `/api/v1/auth/**` | auth-service | Authentication endpoints |
+| `/api/v1/register/**` | auth-service | Registration (public) |
+| `/api/v1/authenticate/**` | auth-service | Authentication (public) |
+| `/api/v1/wallets/**` | wallet-service | Wallet management |
+| `/api/v1/addresses/**` | wallet-service | Address management |
+| `/api/v1/portfolios/**` | portfolio-service | Portfolio tracking |
+| `/api/v1/holdings/**` | portfolio-service | Holdings management |
+| `/api/v1/transactions/**` | transaction-service | Transaction history |
+
+## Public Endpoints (No Auth Required)
+
+- `POST /api/v1/register/**` - User registration
+- `POST /api/v1/authenticate/**` - User authentication
+- `POST /api/v1/auth/refresh` - Token refresh
+- `GET /actuator/health` - Health check
+- `GET /actuator/info` - Service info
+
+## Headers
+
+### Request Headers (Added by Gateway)
+
+| Header | Description |
+|--------|-------------|
+| `X-Request-Id` | Unique request identifier |
+| `X-Correlation-Id` | Correlation ID for distributed tracing |
+| `X-User-Id` | Authenticated user ID (from JWT) |
+| `X-User-Email` | Authenticated user email (from JWT) |
+| `X-User-Roles` | User roles (comma-separated) |
+
+### Response Headers
+
+| Header | Description |
+|--------|-------------|
+| `X-Request-Id` | Echo of request ID |
+| `X-Correlation-Id` | Echo of correlation ID |
+
+## Monitoring
+
+### Actuator Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/actuator/health` | Health status |
+| `/actuator/info` | Application info |
+| `/actuator/metrics` | Metrics data |
+| `/actuator/prometheus` | Prometheus metrics |
+| `/actuator/gateway/routes` | Registered routes |
+
+### Prometheus Metrics
+
+The gateway exposes Prometheus metrics at `/actuator/prometheus` including:
+- Request count and latency
+- Circuit breaker state
+- Rate limiter metrics
+
+## Error Responses
+
+All errors return a consistent JSON structure:
+
+```json
+{
+  "code": "SERVICE_UNAVAILABLE",
+  "message": "Service is temporarily unavailable",
+  "path": "/api/v1/wallets",
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "timestamp": "2026-02-09T10:30:00Z"
+}
+```
+
+### Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `SERVICE_UNAVAILABLE` | 503 | Downstream service unavailable |
+| `GATEWAY_TIMEOUT` | 504 | Request timed out |
+| `GATEWAY_UNAUTHORIZED` | 401 | Invalid or missing JWT |
+| `INTERNAL_ERROR` | 500 | Unexpected error |
+| `AUTH_SERVICE_UNAVAILABLE` | 503 | Auth service circuit open |
+| `WALLET_SERVICE_UNAVAILABLE` | 503 | Wallet service circuit open |
+
+## Circuit Breaker
+
+Circuit breaker configuration per service:
+
+| Parameter | Value |
+|-----------|-------|
+| Sliding window size | 10 |
+| Minimum calls | 5 |
+| Failure rate threshold | 50% |
+| Wait duration (open state) | 10s |
+| Permitted calls (half-open) | 3 |
+
+## Project Structure
+
+```
+mangala-gateway/
+├── src/main/java/org/mangala/gateway/
+│   ├── GatewayApplication.java
+│   ├── config/
+│   │   ├── GatewayConfigProperties.java
+│   │   ├── RateLimiterConfig.java
+│   │   └── SecurityConfig.java
+│   ├── filter/
+│   │   ├── JwtAuthenticationFilter.java
+│   │   └── RequestLoggingFilter.java
+│   ├── exception/
+│   │   ├── GatewayErrorResponse.java
+│   │   └── GlobalExceptionHandler.java
+│   └── health/
+│       ├── FallbackController.java
+│       └── GatewayHealthIndicator.java
+├── src/main/resources/
+│   └── application.yml
+├── Dockerfile
+├── pom.xml
+└── README.md
+```
+
+## License
+
+MIT License - See LICENSE file for details.

--- a/docs/adr/0001-policy-loading-from-auth-internal-api.md
+++ b/docs/adr/0001-policy-loading-from-auth-internal-api.md
@@ -1,0 +1,24 @@
+# ADR 0001: Policy Loading From Auth Internal API
+
+## Status
+Accepted
+
+## Context
+Gateway enforces authorization but policy ownership belongs to `mangala-authentication`.
+Direct gateway reads against auth database create tight coupling and break service boundaries.
+
+## Decision
+Gateway policy loader must use auth internal APIs:
+- `GET /v1/internal/policies`
+- `GET /v1/internal/policies/version`
+
+Gateway compares remote version and only reloads full policy snapshot when version increases.
+Policy cache is atomically swapped to avoid inconsistent reads.
+
+## Consequences
+- Pros:
+  - Preserves ownership boundary of auth service.
+  - Keeps gateway policy behavior consistent and auditable.
+- Cons:
+  - Gateway bootstrap depends on availability and correctness of auth internal API.
+  - Requires secure service-to-service protection for internal endpoints.

--- a/docs/adr/0002-abac-default-deny-no-match.md
+++ b/docs/adr/0002-abac-default-deny-no-match.md
@@ -1,0 +1,19 @@
+# ADR 0002: ABAC No-Match Uses Default Deny
+
+## Status
+Accepted
+
+## Context
+In policy-based authorization, missing policy rules can accidentally expose endpoints when behavior is permissive.
+
+## Decision
+Default no-match behavior is `DENY` and configurable via `gateway.policy.no-match-behavior`.
+Permissive mode `ALLOW` is only for controlled development scenarios.
+
+## Consequences
+- Pros:
+  - Secure-by-default posture for authorization.
+  - Reduces accidental exposure when new routes are introduced without policy.
+- Cons:
+  - Can block traffic if policy data is incomplete or stale.
+  - Requires strong operational discipline for policy rollout.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# ADR Guide
+
+Keep Architecture Decision Records concise and immutable.
+
+## File naming
+- `0001-short-title.md`, `0002-short-title.md`, ...
+
+## Template
+```
+# ADR {N}: {Title}
+
+## Status
+Accepted | Proposed | Superseded
+
+## Context
+What problem are we solving? What constraints exist?
+
+## Decision
+What was chosen?
+
+## Consequences
+Tradeoffs, risks, and follow-up actions.
+```
+
+## Rules
+- Do not rewrite history in old ADRs.
+- If a decision changes, add a new ADR that supersedes old one.
+- Link related ADRs explicitly.

--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -1,0 +1,74 @@
+version: 1
+service:
+  name: mangala-gateway
+  package: org.mangala.gateway
+  runtime: spring-boot-3.4.x + spring-cloud-gateway
+
+entrypoints:
+  main_class: src/main/java/org/mangala/gateway/GatewayApplication.java
+  filter_chain:
+    - src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
+    - src/main/java/org/mangala/gateway/authorization/AbacAuthorizationFilter.java
+
+architecture:
+  style: capability-oriented layers
+  capabilities:
+    - name: authentication
+      package: org.mangala.gateway.filter
+      responsibility: validate JWT and attach user claims context
+    - name: authorization
+      package: org.mangala.gateway.authorization
+      responsibility: permission and ABAC enforcement
+    - name: policy_engine
+      package: org.mangala.gateway.policy
+      responsibility: load/cache/reload policy rules
+    - name: abac_eval
+      package: org.mangala.gateway.abac
+      responsibility: secure SpEL condition evaluation
+    - name: audit
+      package: org.mangala.gateway.audit
+      responsibility: publish authorization decision audit events
+    - name: health
+      package: org.mangala.gateway.health
+      responsibility: policy loader/cache health reporting
+
+security_contracts:
+  inbound_claims:
+    - roles
+    - permissions
+    - email
+  auth_service_internal_apis:
+    - method: GET
+      path: /v1/internal/policies
+      purpose: full active policy snapshot
+    - method: GET
+      path: /v1/internal/policies/version
+      purpose: version check for conditional reload
+
+policy_cache_behavior:
+  cache_type: in_memory
+  match_order:
+    - exact method+path
+    - wildcard method exact path
+    - sorted pattern rules
+  no_match_behavior_config: gateway.policy.no-match-behavior
+
+integration:
+  shared_module:
+    - mangala-common-security
+  external_dependencies:
+    - auth-service (policy source)
+    - redis (version cache and update listener)
+    - kafka (optional audit)
+
+operational_rules:
+  if_changed_then_update_docs:
+    - src/main/java/org/mangala/gateway/policy/
+    - src/main/java/org/mangala/gateway/authorization/
+    - src/main/java/org/mangala/gateway/abac/
+    - mangala-common-security/src/main/java/org/mangala/security/
+    - auth policy API paths in PolicyLoader
+  required_docs:
+    - AGENTS.md
+    - docs/context-map.yaml
+    - docs/adr/

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <!-- Mangala Common Security -->
+        <dependency>
+            <groupId>org.mangala</groupId>
+            <artifactId>common-security</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+
         <!-- JWT Library -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -91,6 +98,28 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <!-- WebFlux (for WebClient) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- Jackson for JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Kafka for Audit Events -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.kafka</groupId>
+            <artifactId>reactor-kafka</artifactId>
         </dependency>
 
         <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.2</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>org.mangala</groupId>
+    <artifactId>gateway</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>mangala-gateway</name>
+    <description>API Gateway for Mangala Wallet Platform</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <lombok.version>1.18.42</lombok.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Cloud Gateway (WebFlux-based) -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+
+        <!-- Reactive Redis for Rate Limiting -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+        </dependency>
+
+        <!-- Circuit Breaker -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
+        </dependency>
+
+        <!-- Security (JWT validation) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- JWT Library -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Actuator for Health Checks -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Micrometer for Metrics -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Configuration Processor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>3.4.2</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -187,4 +187,34 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>context-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>check-context-sync</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <arguments>
+                                        <argument>${project.basedir}/scripts/check-context-sync.sh</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/scripts/check-context-sync.sh
+++ b/scripts/check-context-sync.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CONTEXT_FILE="docs/context-map.yaml"
+ADR_DIR="docs/adr"
+
+if [[ ! -f "$CONTEXT_FILE" ]]; then
+  echo "[FAIL] Missing $CONTEXT_FILE"
+  exit 1
+fi
+
+if [[ ! -d "$ADR_DIR" ]]; then
+  echo "[FAIL] Missing $ADR_DIR"
+  exit 1
+fi
+
+CHANGED_FILES="$(git status --porcelain -uall | awk '{print $2}')"
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo "[OK] No file changes detected."
+  exit 0
+fi
+
+needs_doc_update=0
+
+if echo "$CHANGED_FILES" | grep -qE '^src/main/java/org/mangala/gateway/(policy|authorization|abac)/'; then
+  needs_doc_update=1
+fi
+
+if echo "$CHANGED_FILES" | grep -qE '^mangala-common-security/src/main/java/org/mangala/security/'; then
+  needs_doc_update=1
+fi
+
+if echo "$CHANGED_FILES" | grep -q '^src/main/java/org/mangala/gateway/policy/PolicyLoader.java'; then
+  needs_doc_update=1
+fi
+
+if [[ "$needs_doc_update" -eq 1 ]]; then
+  if ! echo "$CHANGED_FILES" | grep -q '^docs/context-map.yaml'; then
+    echo "[WARN] Policy/authorization-related code changed but docs/context-map.yaml was not updated."
+    exit 2
+  fi
+fi
+
+echo "[OK] Context sync check passed."

--- a/src/main/java/org/mangala/gateway/GatewayApplication.java
+++ b/src/main/java/org/mangala/gateway/GatewayApplication.java
@@ -1,0 +1,14 @@
+package org.mangala.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class GatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
+}

--- a/src/main/java/org/mangala/gateway/GatewayApplication.java
+++ b/src/main/java/org/mangala/gateway/GatewayApplication.java
@@ -3,9 +3,11 @@ package org.mangala.gateway;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class GatewayApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/mangala/gateway/abac/AbacEvaluationContext.java
+++ b/src/main/java/org/mangala/gateway/abac/AbacEvaluationContext.java
@@ -1,0 +1,57 @@
+package org.mangala.gateway.abac;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Immutable context for ABAC condition evaluation.
+ * All values are available as SpEL variables.
+ */
+@Getter
+@Builder
+public class AbacEvaluationContext {
+
+    // User attributes from JWT
+    private final String userId;
+    private final String email;
+    private final Set<String> roles;
+    private final Set<String> permissions;
+    private final Map<String, Object> attributes;
+
+    // Request context
+    private final Map<String, String> pathVariables;  // pathVar['walletId'], etc.
+    private final String httpMethod;
+    private final String path;
+    private final Map<String, String> queryParams;
+
+    /**
+     * Create context with defaults for null values.
+     */
+    public static AbacEvaluationContext of(
+            String userId,
+            String email,
+            Set<String> roles,
+            Set<String> permissions,
+            Map<String, Object> attributes,
+            Map<String, String> pathVariables,
+            String httpMethod,
+            String path,
+            Map<String, String> queryParams) {
+
+        return AbacEvaluationContext.builder()
+                .userId(userId)
+                .email(email)
+                .roles(roles != null ? roles : Collections.emptySet())
+                .permissions(permissions != null ? permissions : Collections.emptySet())
+                .attributes(attributes != null ? attributes : Collections.emptyMap())
+                .pathVariables(pathVariables != null ? pathVariables : Collections.emptyMap())
+                .httpMethod(httpMethod)
+                .path(path)
+                .queryParams(queryParams != null ? queryParams : Collections.emptyMap())
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/abac/ConditionEvaluationException.java
+++ b/src/main/java/org/mangala/gateway/abac/ConditionEvaluationException.java
@@ -1,0 +1,15 @@
+package org.mangala.gateway.abac;
+
+/**
+ * Exception thrown when ABAC condition evaluation fails.
+ */
+public class ConditionEvaluationException extends RuntimeException {
+
+    public ConditionEvaluationException(String message) {
+        super(message);
+    }
+
+    public ConditionEvaluationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/mangala/gateway/abac/RestrictedMethodResolver.java
+++ b/src/main/java/org/mangala/gateway/abac/RestrictedMethodResolver.java
@@ -1,0 +1,40 @@
+package org.mangala.gateway.abac;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.MethodExecutor;
+import org.springframework.expression.MethodResolver;
+import org.springframework.expression.spel.support.ReflectiveMethodResolver;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A method resolver that only allows whitelisted methods.
+ * Prevents calling dangerous methods like getClass(), forName(), exec(), etc.
+ */
+public class RestrictedMethodResolver implements MethodResolver {
+
+    private final Set<String> allowedMethods;
+    private final ReflectiveMethodResolver delegate = new ReflectiveMethodResolver();
+
+    public RestrictedMethodResolver(Set<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    @Override
+    public MethodExecutor resolve(EvaluationContext context, Object targetObject,
+                                  String name, List<TypeDescriptor> argumentTypes) throws AccessException {
+
+        // Check if method is in whitelist
+        if (!allowedMethods.contains(name)) {
+            throw new AccessException(
+                    String.format("Method '%s' is not allowed in ABAC expressions. Allowed: %s",
+                            name, allowedMethods));
+        }
+
+        // Delegate to default resolver for allowed methods
+        return delegate.resolve(context, targetObject, name, argumentTypes);
+    }
+}

--- a/src/main/java/org/mangala/gateway/abac/SpelConditionEvaluator.java
+++ b/src/main/java/org/mangala/gateway/abac/SpelConditionEvaluator.java
@@ -1,0 +1,181 @@
+package org.mangala.gateway.abac;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.regex.Pattern;
+
+/**
+ * Secure SpEL condition evaluator for ABAC expressions.
+ *
+ * Features:
+ * - Expression validation against blocked patterns
+ * - Method call whitelisting
+ * - Evaluation timeout
+ * - Expression caching
+ *
+ * Example expressions:
+ * - #userId == #pathVar['walletId']
+ * - #roles.contains('ADMIN')
+ * - #attributes['tier'] == 'premium'
+ * - #userId == #pathVar['userId'] and #roles.contains('MANAGER')
+ */
+@Slf4j
+@Component
+public class SpelConditionEvaluator {
+
+    private final SpelExpressionCache expressionCache;
+    private final SpelSecurityConfig securityConfig;
+
+    // Thread pool for timeout enforcement
+    private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "spel-evaluator");
+        t.setDaemon(true);
+        return t;
+    });
+
+    // Pre-compiled blocked patterns
+    private List<Pattern> blockedPatterns;
+
+    public SpelConditionEvaluator(SpelExpressionCache expressionCache, SpelSecurityConfig securityConfig) {
+        this.expressionCache = expressionCache;
+        this.securityConfig = securityConfig;
+        this.blockedPatterns = securityConfig.getBlockedPatterns().stream()
+                .map(p -> Pattern.compile(p, Pattern.CASE_INSENSITIVE))
+                .toList();
+    }
+
+    /**
+     * Evaluate a SpEL condition expression.
+     *
+     * @param expression The SpEL expression (e.g., "#userId == #pathVar['walletId']")
+     * @param context    The evaluation context with all variables
+     * @return true if condition is met, false otherwise
+     * @throws ConditionEvaluationException if expression is invalid or blocked
+     */
+    public boolean evaluate(String expression, AbacEvaluationContext context) {
+        if (!securityConfig.isEnabled()) {
+            log.debug("ABAC SpEL evaluation disabled, returning true");
+            return true;
+        }
+
+        if (expression == null || expression.isBlank()) {
+            return true;  // No condition = passes
+        }
+
+        // Security validations
+        validateExpression(expression);
+
+        try {
+            Expression spelExpr = expressionCache.getOrParse(expression);
+            EvaluationContext evalContext = createEvaluationContext(context);
+
+            // Evaluate with timeout
+            Future<Boolean> future = executor.submit(() -> {
+                Boolean result = spelExpr.getValue(evalContext, Boolean.class);
+                return result != null ? result : false;
+            });
+
+            boolean result = future.get(securityConfig.getEvaluationTimeoutMs(), TimeUnit.MILLISECONDS);
+
+            if (log.isDebugEnabled()) {
+                log.debug("SpEL evaluation: '{}' = {}", expression, result);
+            }
+
+            return result;
+
+        } catch (TimeoutException e) {
+            log.warn("SpEL evaluation timed out for expression: {}", expression);
+            throw new ConditionEvaluationException("Expression evaluation timed out");
+
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            log.warn("SpEL evaluation failed for expression '{}': {}", expression, cause.getMessage());
+            throw new ConditionEvaluationException("Expression evaluation failed: " + cause.getMessage(), cause);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ConditionEvaluationException("Expression evaluation interrupted");
+
+        } catch (Exception e) {
+            log.warn("SpEL evaluation error for expression '{}': {}", expression, e.getMessage());
+            throw new ConditionEvaluationException("Expression evaluation error: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Evaluate safely, returning false on any error (fail-closed).
+     */
+    public boolean evaluateSafe(String expression, AbacEvaluationContext context) {
+        try {
+            return evaluate(expression, context);
+        } catch (Exception e) {
+            log.warn("Safe evaluation failed, returning false: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Validate expression before parsing.
+     */
+    private void validateExpression(String expression) {
+        // Length check
+        if (expression.length() > securityConfig.getMaxExpressionLength()) {
+            throw new ConditionEvaluationException(
+                    "Expression exceeds maximum length of " + securityConfig.getMaxExpressionLength());
+        }
+
+        // Check for blocked patterns
+        for (Pattern pattern : blockedPatterns) {
+            if (pattern.matcher(expression).find()) {
+                log.warn("Blocked expression pattern detected: {}", expression);
+                throw new ConditionEvaluationException(
+                        "Expression contains blocked pattern");
+            }
+        }
+    }
+
+    /**
+     * Create a restricted evaluation context.
+     */
+    private EvaluationContext createEvaluationContext(AbacEvaluationContext context) {
+        StandardEvaluationContext evalContext = new StandardEvaluationContext();
+
+        // Set allowed variables
+        evalContext.setVariable("userId", context.getUserId());
+        evalContext.setVariable("email", context.getEmail());
+        evalContext.setVariable("roles", context.getRoles());
+        evalContext.setVariable("permissions", context.getPermissions());
+        evalContext.setVariable("attributes", context.getAttributes());
+        evalContext.setVariable("pathVar", context.getPathVariables());
+        evalContext.setVariable("httpMethod", context.getHttpMethod());
+        evalContext.setVariable("path", context.getPath());
+        evalContext.setVariable("queryParams", context.getQueryParams());
+
+        // Use restricted method resolver
+        evalContext.setMethodResolvers(
+                List.of(new RestrictedMethodResolver(securityConfig.getAllowedMethods()))
+        );
+
+        return evalContext;
+    }
+
+    /**
+     * Get expression cache statistics.
+     */
+    public SpelExpressionCache.CacheStats getCacheStats() {
+        return expressionCache.getStats();
+    }
+
+    /**
+     * Clear the expression cache.
+     */
+    public void clearCache() {
+        expressionCache.clear();
+    }
+}

--- a/src/main/java/org/mangala/gateway/abac/SpelExpressionCache.java
+++ b/src/main/java/org/mangala/gateway/abac/SpelExpressionCache.java
@@ -1,0 +1,111 @@
+package org.mangala.gateway.abac;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Cache for compiled SpEL expressions.
+ * Thread-safe implementation using ConcurrentHashMap.
+ */
+@Slf4j
+@Component
+public class SpelExpressionCache {
+
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+    private final ConcurrentHashMap<String, Expression> cache = new ConcurrentHashMap<>();
+    private final SpelSecurityConfig securityConfig;
+
+    private final AtomicLong cacheHits = new AtomicLong(0);
+    private final AtomicLong cacheMisses = new AtomicLong(0);
+
+    public SpelExpressionCache(SpelSecurityConfig securityConfig) {
+        this.securityConfig = securityConfig;
+    }
+
+    /**
+     * Get a compiled expression from cache or parse and cache it.
+     *
+     * @param expressionString The SpEL expression string
+     * @return Compiled Expression
+     */
+    public Expression getOrParse(String expressionString) {
+        Expression cached = cache.get(expressionString);
+        if (cached != null) {
+            cacheHits.incrementAndGet();
+            return cached;
+        }
+
+        cacheMisses.incrementAndGet();
+
+        // Evict if cache is full (simple eviction - remove ~10% of entries)
+        if (cache.size() >= securityConfig.getMaxCacheSize()) {
+            evictOldEntries();
+        }
+
+        Expression expression = parser.parseExpression(expressionString);
+        cache.put(expressionString, expression);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Cached new expression: {}", expressionString);
+        }
+
+        return expression;
+    }
+
+    /**
+     * Clear all cached expressions.
+     */
+    public void clear() {
+        cache.clear();
+        cacheHits.set(0);
+        cacheMisses.set(0);
+        log.info("Expression cache cleared");
+    }
+
+    /**
+     * Get current cache size.
+     */
+    public int size() {
+        return cache.size();
+    }
+
+    /**
+     * Get cache hit ratio.
+     */
+    public double getHitRatio() {
+        long total = cacheHits.get() + cacheMisses.get();
+        return total > 0 ? (double) cacheHits.get() / total : 0.0;
+    }
+
+    /**
+     * Get cache statistics.
+     */
+    public CacheStats getStats() {
+        return new CacheStats(
+                cache.size(),
+                cacheHits.get(),
+                cacheMisses.get(),
+                getHitRatio()
+        );
+    }
+
+    private void evictOldEntries() {
+        int toRemove = securityConfig.getMaxCacheSize() / 10;
+        int removed = 0;
+
+        for (String key : cache.keySet()) {
+            if (removed >= toRemove) break;
+            cache.remove(key);
+            removed++;
+        }
+
+        log.debug("Evicted {} expressions from cache", removed);
+    }
+
+    public record CacheStats(int size, long hits, long misses, double hitRatio) {}
+}

--- a/src/main/java/org/mangala/gateway/abac/SpelSecurityConfig.java
+++ b/src/main/java/org/mangala/gateway/abac/SpelSecurityConfig.java
@@ -1,0 +1,102 @@
+package org.mangala.gateway.abac;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Security configuration for SpEL expression evaluation.
+ * Controls what expressions are allowed and their execution limits.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "gateway.abac.spel")
+public class SpelSecurityConfig {
+
+    /**
+     * Enable/disable ABAC condition evaluation.
+     * When disabled, all conditions return true (pass).
+     */
+    private boolean enabled = true;
+
+    /**
+     * Maximum allowed expression length.
+     */
+    private int maxExpressionLength = 500;
+
+    /**
+     * Expression evaluation timeout in milliseconds.
+     */
+    private long evaluationTimeoutMs = 100;
+
+    /**
+     * Maximum cache size for compiled expressions.
+     */
+    private int maxCacheSize = 1000;
+
+    /**
+     * Allowed top-level variable names accessible in expressions.
+     */
+    private Set<String> allowedVariables = Set.of(
+            "userId",
+            "email",
+            "roles",
+            "permissions",
+            "attributes",
+            "pathVar",
+            "httpMethod",
+            "path",
+            "queryParams"
+    );
+
+    /**
+     * Allowed method calls on objects.
+     * Restrict to safe methods only.
+     */
+    private Set<String> allowedMethods = Set.of(
+            "contains",
+            "containsKey",
+            "containsValue",
+            "equals",
+            "equalsIgnoreCase",
+            "isEmpty",
+            "size",
+            "get",
+            "startsWith",
+            "endsWith",
+            "toLowerCase",
+            "toUpperCase",
+            "matches",
+            "toString",
+            "length"
+    );
+
+    /**
+     * Blocked patterns in expressions (regex).
+     * These patterns indicate potential security risks.
+     */
+    private Set<String> blockedPatterns = Set.of(
+            "T\\s*\\(",           // Type references T(...)
+            "new\\s+",            // Object instantiation
+            "getClass",           // Reflection
+            "forName",            // Class loading
+            "invoke",             // Method invocation via reflection
+            "Runtime",            // Runtime access
+            "ProcessBuilder",     // Process execution
+            "System\\.",          // System access
+            "exec",               // Execution
+            "\\$\\{",             // Property placeholder
+            "#\\{",               // SpEL in SpEL
+            "java\\.lang",        // Java lang classes
+            "java\\.io",          // Java IO classes
+            "java\\.net",         // Java net classes
+            "java\\.util\\.concurrent", // Concurrent utilities
+            "Thread",             // Thread manipulation
+            "Class\\.",           // Class methods
+            "ClassLoader"         // ClassLoader access
+    );
+}

--- a/src/main/java/org/mangala/gateway/audit/AuditConfig.java
+++ b/src/main/java/org/mangala/gateway/audit/AuditConfig.java
@@ -1,0 +1,50 @@
+package org.mangala.gateway.audit;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import reactor.kafka.sender.SenderOptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka producer configuration for audit events.
+ * Configured for fire-and-forget, non-blocking operation.
+ */
+@Configuration
+@ConditionalOnProperty(value = "gateway.audit.enabled", havingValue = "true")
+public class AuditConfig {
+
+    @Bean
+    public ReactiveKafkaProducerTemplate<String, AuthorizationAuditEvent> auditKafkaTemplate(
+            AuditConfigProperties auditConfig) {
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, auditConfig.getKafkaBootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        // Fire-and-forget settings for non-blocking operation
+        props.put(ProducerConfig.ACKS_CONFIG, "0");  // Don't wait for acks
+        props.put(ProducerConfig.RETRIES_CONFIG, 0);  // No retries
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, auditConfig.getBatchSize());
+        props.put(ProducerConfig.LINGER_MS_CONFIG, auditConfig.getLingerMs());
+        props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, auditConfig.getBufferMemory());
+
+        // Prevent blocking the request thread
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, auditConfig.getMaxBlockMs());
+
+        // Compression for efficiency
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
+
+        SenderOptions<String, AuthorizationAuditEvent> senderOptions =
+                SenderOptions.create(props);
+
+        return new ReactiveKafkaProducerTemplate<>(senderOptions);
+    }
+}

--- a/src/main/java/org/mangala/gateway/audit/AuditConfigProperties.java
+++ b/src/main/java/org/mangala/gateway/audit/AuditConfigProperties.java
@@ -1,0 +1,62 @@
+package org.mangala.gateway.audit;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for authorization audit logging.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "gateway.audit")
+public class AuditConfigProperties {
+
+    /**
+     * Enable/disable audit logging.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Kafka bootstrap servers.
+     */
+    private String kafkaBootstrapServers = "localhost:9092";
+
+    /**
+     * Kafka producer batch size.
+     */
+    private int batchSize = 16384;
+
+    /**
+     * Kafka producer linger time in milliseconds.
+     */
+    private int lingerMs = 10;
+
+    /**
+     * Kafka producer buffer memory.
+     */
+    private long bufferMemory = 33554432; // 32MB
+
+    /**
+     * Whether to audit allowed requests.
+     */
+    private boolean auditAllowedRequests = true;
+
+    /**
+     * Whether to audit denied requests.
+     */
+    private boolean auditDeniedRequests = true;
+
+    /**
+     * Whether to audit requests with no matching policy.
+     */
+    private boolean auditNoPolicyRequests = true;
+
+    /**
+     * Maximum time to block when buffer is full (ms).
+     * Low value prevents blocking the request.
+     */
+    private int maxBlockMs = 100;
+}

--- a/src/main/java/org/mangala/gateway/audit/AuthorizationAuditEvent.java
+++ b/src/main/java/org/mangala/gateway/audit/AuthorizationAuditEvent.java
@@ -1,0 +1,164 @@
+package org.mangala.gateway.audit;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mangala.security.model.AuthorizationResult;
+
+import java.time.Instant;
+import java.util.Set;
+
+/**
+ * Audit event for authorization decisions.
+ * Published to Kafka for security auditing and compliance.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorizationAuditEvent {
+
+    /**
+     * Unique request identifier for correlation.
+     */
+    private String requestId;
+
+    /**
+     * Correlation ID for distributed tracing.
+     */
+    private String correlationId;
+
+    /**
+     * User ID from JWT subject.
+     */
+    private String userId;
+
+    /**
+     * User email.
+     */
+    private String email;
+
+    /**
+     * HTTP method (GET, POST, etc.)
+     */
+    private String httpMethod;
+
+    /**
+     * Original request path.
+     */
+    private String path;
+
+    /**
+     * Normalized path (lowercase, decoded).
+     */
+    private String normalizedPath;
+
+    /**
+     * Authorization decision: ALLOW, DENY, or NO_POLICY.
+     */
+    private AuthorizationResult.Decision decision;
+
+    /**
+     * Reason for denial (if denied).
+     */
+    private String reason;
+
+    /**
+     * Permissions required by the policy rule.
+     */
+    private Set<String> requiredPermissions;
+
+    /**
+     * Permissions the user has.
+     */
+    private Set<String> userPermissions;
+
+    /**
+     * User roles.
+     */
+    private Set<String> userRoles;
+
+    /**
+     * Matched policy rule identifier.
+     */
+    private String matchedRule;
+
+    /**
+     * ABAC condition expression (if any).
+     */
+    private String conditionExpr;
+
+    /**
+     * Result of ABAC condition evaluation.
+     */
+    private Boolean conditionResult;
+
+    /**
+     * Time taken to evaluate authorization (ms).
+     */
+    private long evaluationTimeMs;
+
+    /**
+     * Event timestamp.
+     */
+    private Instant timestamp;
+
+    /**
+     * Client IP address.
+     */
+    private String clientIp;
+
+    /**
+     * User-Agent header.
+     */
+    private String userAgent;
+
+    /**
+     * Service name (gateway).
+     */
+    private String serviceName;
+
+    /**
+     * Create event from authorization result and request context.
+     */
+    public static AuthorizationAuditEvent from(
+            String requestId,
+            String correlationId,
+            String userId,
+            String email,
+            String httpMethod,
+            String path,
+            String normalizedPath,
+            AuthorizationResult result,
+            Set<String> userPermissions,
+            Set<String> userRoles,
+            String conditionExpr,
+            Boolean conditionResult,
+            String clientIp,
+            String userAgent) {
+
+        return AuthorizationAuditEvent.builder()
+                .requestId(requestId)
+                .correlationId(correlationId)
+                .userId(userId)
+                .email(email)
+                .httpMethod(httpMethod)
+                .path(path)
+                .normalizedPath(normalizedPath)
+                .decision(result.getDecision())
+                .reason(result.getReason())
+                .requiredPermissions(result.getRequiredPermissions())
+                .userPermissions(userPermissions)
+                .userRoles(userRoles)
+                .matchedRule(result.getMatchedRule())
+                .conditionExpr(conditionExpr)
+                .conditionResult(conditionResult)
+                .evaluationTimeMs(result.getEvaluationTimeMs())
+                .timestamp(Instant.now())
+                .clientIp(clientIp)
+                .userAgent(userAgent)
+                .serviceName("mangala-gateway")
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/audit/AuthorizationAuditPublisher.java
+++ b/src/main/java/org/mangala/gateway/audit/AuthorizationAuditPublisher.java
@@ -1,0 +1,152 @@
+package org.mangala.gateway.audit;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.security.SecurityConstants;
+import org.mangala.security.model.AuthorizationResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Publishes authorization audit events to Kafka.
+ * Non-blocking, fire-and-forget operation that never affects request latency.
+ */
+@Slf4j
+@Component
+public class AuthorizationAuditPublisher {
+
+    private final ReactiveKafkaProducerTemplate<String, AuthorizationAuditEvent> kafkaTemplate;
+    private final AuditConfigProperties auditConfig;
+
+    // Metrics
+    private final AtomicLong publishedCount = new AtomicLong(0);
+    private final AtomicLong failedCount = new AtomicLong(0);
+
+    @Autowired(required = false)
+    public AuthorizationAuditPublisher(
+            ReactiveKafkaProducerTemplate<String, AuthorizationAuditEvent> kafkaTemplate,
+            AuditConfigProperties auditConfig) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.auditConfig = auditConfig;
+    }
+
+    /**
+     * Constructor when Kafka is disabled.
+     */
+    public AuthorizationAuditPublisher(AuditConfigProperties auditConfig) {
+        this.kafkaTemplate = null;
+        this.auditConfig = auditConfig;
+    }
+
+    /**
+     * Publish audit event asynchronously - fire and forget.
+     * Non-blocking, errors are logged but never propagated.
+     */
+    public void publishAsync(AuthorizationAuditEvent event) {
+        if (!shouldPublish(event)) {
+            return;
+        }
+
+        if (kafkaTemplate == null) {
+            log.trace("Kafka not configured, skipping audit event");
+            return;
+        }
+
+        kafkaTemplate.send(
+                        SecurityConstants.TOPIC_AUTHORIZATION_AUDIT,
+                        event.getRequestId(),  // Use requestId as key for ordering
+                        event
+                )
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> {
+                    publishedCount.incrementAndGet();
+                    if (log.isTraceEnabled()) {
+                        log.trace("Audit event published: requestId={}, decision={}",
+                                event.getRequestId(), event.getDecision());
+                    }
+                })
+                .doOnError(e -> {
+                    failedCount.incrementAndGet();
+                    log.warn("Failed to publish audit event: requestId={}, error={}",
+                            event.getRequestId(), e.getMessage());
+                })
+                .subscribe();  // Fire and forget
+    }
+
+    /**
+     * Publish with Mono return for testing or when chaining is needed.
+     */
+    public Mono<Void> publish(AuthorizationAuditEvent event) {
+        if (!shouldPublish(event)) {
+            return Mono.empty();
+        }
+
+        if (kafkaTemplate == null) {
+            return Mono.empty();
+        }
+
+        return kafkaTemplate.send(
+                        SecurityConstants.TOPIC_AUTHORIZATION_AUDIT,
+                        event.getRequestId(),
+                        event
+                )
+                .doOnSuccess(result -> publishedCount.incrementAndGet())
+                .doOnError(e -> {
+                    failedCount.incrementAndGet();
+                    log.warn("Failed to publish audit event", e);
+                })
+                .then();
+    }
+
+    /**
+     * Check if this event should be published based on configuration.
+     */
+    private boolean shouldPublish(AuthorizationAuditEvent event) {
+        if (!auditConfig.isEnabled()) {
+            return false;
+        }
+
+        if (event == null || event.getDecision() == null) {
+            return false;
+        }
+
+        return switch (event.getDecision()) {
+            case ALLOW -> auditConfig.isAuditAllowedRequests();
+            case DENY -> auditConfig.isAuditDeniedRequests();
+            case NO_POLICY -> auditConfig.isAuditNoPolicyRequests();
+        };
+    }
+
+    /**
+     * Check if audit publishing is enabled.
+     */
+    public boolean isEnabled() {
+        return auditConfig.isEnabled() && kafkaTemplate != null;
+    }
+
+    /**
+     * Get count of successfully published events.
+     */
+    public long getPublishedCount() {
+        return publishedCount.get();
+    }
+
+    /**
+     * Get count of failed publish attempts.
+     */
+    public long getFailedCount() {
+        return failedCount.get();
+    }
+
+    /**
+     * Reset metrics counters.
+     */
+    public void resetMetrics() {
+        publishedCount.set(0);
+        failedCount.set(0);
+    }
+}

--- a/src/main/java/org/mangala/gateway/audit/AuthorizationAuditPublisher.java
+++ b/src/main/java/org/mangala/gateway/audit/AuthorizationAuditPublisher.java
@@ -2,10 +2,10 @@ package org.mangala.gateway.audit;
 
 import lombok.extern.slf4j.Slf4j;
 import org.mangala.security.SecurityConstants;
-import org.mangala.security.model.AuthorizationResult;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -16,7 +16,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * Non-blocking, fire-and-forget operation that never affects request latency.
  */
 @Slf4j
-@Component
+@Service
+@ConditionalOnProperty(value = "gateway.audit.enabled", havingValue = "true")
+@ConditionalOnBean(ReactiveKafkaProducerTemplate.class)
 public class AuthorizationAuditPublisher {
 
     private final ReactiveKafkaProducerTemplate<String, AuthorizationAuditEvent> kafkaTemplate;
@@ -26,19 +28,10 @@ public class AuthorizationAuditPublisher {
     private final AtomicLong publishedCount = new AtomicLong(0);
     private final AtomicLong failedCount = new AtomicLong(0);
 
-    @Autowired(required = false)
     public AuthorizationAuditPublisher(
             ReactiveKafkaProducerTemplate<String, AuthorizationAuditEvent> kafkaTemplate,
             AuditConfigProperties auditConfig) {
         this.kafkaTemplate = kafkaTemplate;
-        this.auditConfig = auditConfig;
-    }
-
-    /**
-     * Constructor when Kafka is disabled.
-     */
-    public AuthorizationAuditPublisher(AuditConfigProperties auditConfig) {
-        this.kafkaTemplate = null;
         this.auditConfig = auditConfig;
     }
 

--- a/src/main/java/org/mangala/gateway/authorization/AbacAuthorizationFilter.java
+++ b/src/main/java/org/mangala/gateway/authorization/AbacAuthorizationFilter.java
@@ -1,0 +1,439 @@
+package org.mangala.gateway.authorization;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.gateway.abac.AbacEvaluationContext;
+import org.mangala.gateway.abac.SpelConditionEvaluator;
+import org.mangala.gateway.audit.AuthorizationAuditEvent;
+import org.mangala.gateway.audit.AuthorizationAuditPublisher;
+import org.mangala.gateway.config.GatewayConfigProperties;
+import org.mangala.gateway.policy.PolicyCache;
+import org.mangala.gateway.policy.PolicyConfigProperties;
+import org.mangala.security.SecurityConstants;
+import org.mangala.security.model.AuthorizationResult;
+import org.mangala.security.model.PolicyRule;
+import org.mangala.security.util.PathNormalizer;
+import org.mangala.security.util.PermissionMatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.net.InetSocketAddress;
+import java.util.*;
+
+/**
+ * ABAC Authorization Filter that enforces permission-based access control.
+ *
+ * This filter:
+ * 1. Extracts user permissions from JWT (via SecurityContext)
+ * 2. Matches request path to policy rules (from in-memory cache)
+ * 3. Checks if user has required permissions
+ * 4. Evaluates ABAC conditions if present (using SpEL)
+ * 5. Publishes audit events to Kafka
+ * 6. Returns 403 if unauthorized
+ */
+@Slf4j
+@Component
+public class AbacAuthorizationFilter implements WebFilter, Ordered {
+
+    private final PolicyCache policyCache;
+    private final PolicyConfigProperties policyConfig;
+    private final GatewayConfigProperties gatewayConfig;
+    private final SpelConditionEvaluator spelConditionEvaluator;
+    private final AuthorizationAuditPublisher auditPublisher;
+
+    @Autowired
+    public AbacAuthorizationFilter(
+            PolicyCache policyCache,
+            PolicyConfigProperties policyConfig,
+            GatewayConfigProperties gatewayConfig,
+            SpelConditionEvaluator spelConditionEvaluator,
+            @Autowired(required = false) AuthorizationAuditPublisher auditPublisher) {
+        this.policyCache = policyCache;
+        this.policyConfig = policyConfig;
+        this.gatewayConfig = gatewayConfig;
+        this.spelConditionEvaluator = spelConditionEvaluator;
+        this.auditPublisher = auditPublisher;
+    }
+
+    @Override
+    public int getOrder() {
+        // Run after authentication filter
+        return Ordered.LOWEST_PRECEDENCE - 10;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        String path = PathNormalizer.normalize(request.getPath().value());
+        String method = request.getMethod().name();
+
+        // Skip public paths
+        if (isPublicPath(path)) {
+            return chain.filter(exchange);
+        }
+
+        // Skip if policy cache is not healthy
+        if (!policyCache.isHealthy()) {
+            log.error("Policy cache unhealthy, denying all requests");
+            return respondServiceUnavailable(exchange);
+        }
+
+        // Check path for security issues
+        if (!PathNormalizer.isValidPath(path)) {
+            log.warn("Invalid path detected: {}", request.getPath().value());
+            return respondBadRequest(exchange, "Invalid request path");
+        }
+
+        return ReactiveSecurityContextHolder.getContext()
+                .map(ctx -> ctx.getAuthentication())
+                .flatMap(auth -> authorize(auth, method, path, exchange))
+                .switchIfEmpty(Mono.defer(() -> {
+                    // No authentication context - check if endpoint requires auth
+                    return authorizeUnauthenticated(method, path, exchange, chain);
+                }))
+                .flatMap(result -> {
+                    if (result.isAllowed()) {
+                        return chain.filter(enrichRequest(exchange, result));
+                    } else {
+                        return respondForbidden(exchange, result);
+                    }
+                });
+    }
+
+    private Mono<AuthorizationResult> authorize(Authentication auth, String method, String path, ServerWebExchange exchange) {
+        long startTime = System.currentTimeMillis();
+
+        if (auth == null || !auth.isAuthenticated()) {
+            AuthorizationResult result = AuthorizationResult.deny("Not authenticated", Collections.emptySet());
+            publishAuditEvent(exchange, null, path, result, null, null, null, null);
+            return Mono.just(result);
+        }
+
+        // Extract user details
+        String userId = (String) auth.getPrincipal();
+        Map<String, Object> details = extractAuthDetails(auth);
+        Set<String> userPermissions = extractPermissions(auth);
+        Set<String> userRoles = extractRoles(details);
+        String email = (String) details.getOrDefault("email", null);
+
+        // Find matching policy rule
+        Optional<PolicyRule> ruleOpt = policyCache.findMatchingRule(method, path);
+
+        if (ruleOpt.isEmpty()) {
+            // No policy rule found
+            AuthorizationResult result = handleNoMatchingRuleSync(method, path, startTime);
+            publishAuditEvent(exchange, auth, path, result, userPermissions, userRoles, null, null);
+            return Mono.just(result);
+        }
+
+        PolicyRule rule = ruleOpt.get();
+        Set<String> requiredPermissions = rule.getRequiredPermissions();
+
+        // Check if user has any of the required permissions
+        boolean hasPermission = PermissionMatcher.hasAnyPermission(userPermissions, requiredPermissions);
+
+        if (!hasPermission) {
+            log.info("Authorization denied for {} {}. Required: {}, User has: {}",
+                    method, path, requiredPermissions, userPermissions);
+
+            AuthorizationResult result = AuthorizationResult.deny(
+                    "Insufficient permissions",
+                    requiredPermissions
+            );
+            result.setEvaluationTimeMs(System.currentTimeMillis() - startTime);
+            publishAuditEvent(exchange, auth, path, result, userPermissions, userRoles, rule.getConditionExpr(), null);
+            return Mono.just(result);
+        }
+
+        // Evaluate ABAC conditions if present
+        Boolean conditionResult = null;
+        if (rule.getConditionExpr() != null && !rule.getConditionExpr().isEmpty()) {
+            conditionResult = evaluateCondition(rule, auth, exchange);
+            if (!conditionResult) {
+                log.info("ABAC condition failed for {} {}: {}", method, path, rule.getConditionExpr());
+                AuthorizationResult result = AuthorizationResult.deny(
+                        "Access condition not met",
+                        requiredPermissions
+                );
+                result.setEvaluationTimeMs(System.currentTimeMillis() - startTime);
+                publishAuditEvent(exchange, auth, path, result, userPermissions, userRoles, rule.getConditionExpr(), conditionResult);
+                return Mono.just(result);
+            }
+        }
+
+        AuthorizationResult result = AuthorizationResult.allow(rule.getCacheKey());
+        result.setEvaluationTimeMs(System.currentTimeMillis() - startTime);
+        publishAuditEvent(exchange, auth, path, result, userPermissions, userRoles, rule.getConditionExpr(), conditionResult);
+        return Mono.just(result);
+    }
+
+    private Mono<AuthorizationResult> authorizeUnauthenticated(String method, String path,
+                                                                ServerWebExchange exchange,
+                                                                WebFilterChain chain) {
+        // Check if this endpoint has any policy rules
+        Optional<PolicyRule> ruleOpt = policyCache.findMatchingRule(method, path);
+
+        AuthorizationResult result;
+        if (ruleOpt.isEmpty()) {
+            // No policy = use default behavior
+            if (policyConfig.getNoMatchBehavior() == PolicyConfigProperties.NoMatchBehavior.ALLOW) {
+                result = AuthorizationResult.allow("no-policy-allow");
+            } else {
+                result = AuthorizationResult.noPolicy(path);
+            }
+        } else {
+            // Has policy but no auth = deny
+            result = AuthorizationResult.deny("Authentication required", ruleOpt.get().getRequiredPermissions());
+        }
+
+        publishAuditEvent(exchange, null, path, result, null, null, null, null);
+        return Mono.just(result);
+    }
+
+    private AuthorizationResult handleNoMatchingRuleSync(String method, String path, long startTime) {
+        AuthorizationResult result;
+        if (policyConfig.getNoMatchBehavior() == PolicyConfigProperties.NoMatchBehavior.ALLOW) {
+            log.debug("No policy rule for {} {}, allowing (permissive mode)", method, path);
+            result = AuthorizationResult.allow("no-policy-allow");
+        } else {
+            log.warn("No policy rule found for {} {}. Denying request.", method, path);
+            result = AuthorizationResult.noPolicy(path);
+        }
+        result.setEvaluationTimeMs(System.currentTimeMillis() - startTime);
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractAuthDetails(Authentication auth) {
+        if (auth.getDetails() instanceof Map) {
+            return (Map<String, Object>) auth.getDetails();
+        }
+        return Collections.emptyMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> extractPermissions(Authentication auth) {
+        Set<String> permissions = new HashSet<>();
+
+        // Try to get permissions from authentication details
+        Map<String, Object> details = extractAuthDetails(auth);
+        Object perms = details.get("permissions");
+        if (perms instanceof Collection) {
+            ((Collection<?>) perms).forEach(p -> permissions.add(p.toString()));
+        }
+
+        // Also extract from authorities (roles)
+        auth.getAuthorities().forEach(a -> {
+            String authority = a.getAuthority();
+            // If authority looks like a permission (contains :), add it
+            if (authority.contains(":")) {
+                permissions.add(authority);
+            }
+        });
+
+        return permissions;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> extractRoles(Map<String, Object> details) {
+        Object roles = details.get("roles");
+        if (roles instanceof Set) {
+            return (Set<String>) roles;
+        } else if (roles instanceof Collection) {
+            Set<String> roleSet = new HashSet<>();
+            ((Collection<?>) roles).forEach(r -> roleSet.add(r.toString()));
+            return roleSet;
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Evaluate ABAC condition using SpEL.
+     */
+    @SuppressWarnings("unchecked")
+    private boolean evaluateCondition(PolicyRule rule, Authentication auth, ServerWebExchange exchange) {
+        try {
+            ServerHttpRequest request = exchange.getRequest();
+
+            // Extract user details from authentication
+            String userId = (String) auth.getPrincipal();
+            Map<String, Object> details = extractAuthDetails(auth);
+
+            String email = (String) details.getOrDefault("email", null);
+            Set<String> roles = extractRoles(details);
+            Set<String> permissions = details.get("permissions") instanceof Set
+                    ? (Set<String>) details.get("permissions")
+                    : Collections.emptySet();
+            Map<String, Object> attributes = details.get("attributes") instanceof Map
+                    ? (Map<String, Object>) details.get("attributes")
+                    : Collections.emptyMap();
+
+            // Extract path variables from URL
+            Map<String, String> pathVariables = PathNormalizer.extractPathVariables(
+                    rule.getPathPattern(),
+                    request.getPath().value()
+            );
+
+            // Extract query parameters
+            Map<String, String> queryParams = new HashMap<>();
+            request.getQueryParams().forEach((key, values) -> {
+                if (!values.isEmpty()) {
+                    queryParams.put(key, values.get(0));
+                }
+            });
+
+            // Build evaluation context
+            AbacEvaluationContext context = AbacEvaluationContext.of(
+                    userId,
+                    email,
+                    roles,
+                    permissions,
+                    attributes,
+                    pathVariables,
+                    request.getMethod().name(),
+                    request.getPath().value(),
+                    queryParams
+            );
+
+            // Evaluate using SpEL (fail-closed: returns false on any error)
+            return spelConditionEvaluator.evaluateSafe(rule.getConditionExpr(), context);
+
+        } catch (Exception e) {
+            log.warn("Error preparing ABAC evaluation context: {}", e.getMessage());
+            return false; // Fail closed
+        }
+    }
+
+    /**
+     * Publish authorization audit event asynchronously.
+     */
+    private void publishAuditEvent(
+            ServerWebExchange exchange,
+            Authentication auth,
+            String normalizedPath,
+            AuthorizationResult result,
+            Set<String> userPermissions,
+            Set<String> userRoles,
+            String conditionExpr,
+            Boolean conditionResult) {
+
+        if (auditPublisher == null || !auditPublisher.isEnabled()) {
+            return;
+        }
+
+        try {
+            ServerHttpRequest request = exchange.getRequest();
+
+            String requestId = request.getHeaders().getFirst(SecurityConstants.HEADER_REQUEST_ID);
+            String correlationId = request.getHeaders().getFirst(SecurityConstants.HEADER_CORRELATION_ID);
+            String userId = auth != null ? (String) auth.getPrincipal() : null;
+            String email = null;
+
+            if (auth != null) {
+                Map<String, Object> details = extractAuthDetails(auth);
+                email = (String) details.getOrDefault("email", null);
+            }
+
+            String clientIp = extractClientIp(request);
+            String userAgent = request.getHeaders().getFirst("User-Agent");
+
+            AuthorizationAuditEvent event = AuthorizationAuditEvent.from(
+                    requestId,
+                    correlationId,
+                    userId,
+                    email,
+                    request.getMethod().name(),
+                    request.getPath().value(),
+                    normalizedPath,
+                    result,
+                    userPermissions,
+                    userRoles,
+                    conditionExpr,
+                    conditionResult,
+                    clientIp,
+                    userAgent
+            );
+
+            auditPublisher.publishAsync(event);
+
+        } catch (Exception e) {
+            log.warn("Failed to publish audit event: {}", e.getMessage());
+        }
+    }
+
+    private String extractClientIp(ServerHttpRequest request) {
+        // Check forwarded headers first
+        String forwardedFor = request.getHeaders().getFirst("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            // Take first IP if multiple
+            return forwardedFor.split(",")[0].trim();
+        }
+
+        String realIp = request.getHeaders().getFirst("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp;
+        }
+
+        // Fallback to remote address
+        InetSocketAddress remoteAddress = request.getRemoteAddress();
+        if (remoteAddress != null && remoteAddress.getAddress() != null) {
+            return remoteAddress.getAddress().getHostAddress();
+        }
+
+        return "unknown";
+    }
+
+    private boolean isPublicPath(String path) {
+        return gatewayConfig.getPublicPaths().stream()
+                .anyMatch(pattern -> matchesPublicPath(pattern, path));
+    }
+
+    private boolean matchesPublicPath(String pattern, String path) {
+        if (pattern.endsWith("/**")) {
+            String prefix = pattern.substring(0, pattern.length() - 3);
+            return path.startsWith(prefix);
+        } else if (pattern.endsWith("/*")) {
+            String prefix = pattern.substring(0, pattern.length() - 2);
+            return path.startsWith(prefix) && !path.substring(prefix.length()).contains("/");
+        }
+        return pattern.equals(path);
+    }
+
+    private ServerWebExchange enrichRequest(ServerWebExchange exchange, AuthorizationResult result) {
+        // Add authorization metadata to headers for downstream services
+        ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+                .header("X-Authorization-Rule", result.getMatchedRule() != null ? result.getMatchedRule() : "none")
+                .build();
+
+        return exchange.mutate().request(mutatedRequest).build();
+    }
+
+    private Mono<Void> respondForbidden(ServerWebExchange exchange, AuthorizationResult result) {
+        exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+        exchange.getResponse().getHeaders().add(
+                SecurityConstants.HEADER_FORBIDDEN_REASON,
+                result.getReason() != null ? result.getReason() : "Access denied"
+        );
+        return exchange.getResponse().setComplete();
+    }
+
+    private Mono<Void> respondServiceUnavailable(ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.SERVICE_UNAVAILABLE);
+        exchange.getResponse().getHeaders().add("Retry-After", "30");
+        return exchange.getResponse().setComplete();
+    }
+
+    private Mono<Void> respondBadRequest(ServerWebExchange exchange, String reason) {
+        exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+        exchange.getResponse().getHeaders().add(SecurityConstants.HEADER_FORBIDDEN_REASON, reason);
+        return exchange.getResponse().setComplete();
+    }
+}

--- a/src/main/java/org/mangala/gateway/config/GatewayConfigProperties.java
+++ b/src/main/java/org/mangala/gateway/config/GatewayConfigProperties.java
@@ -1,0 +1,48 @@
+package org.mangala.gateway.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "gateway")
+public class GatewayConfigProperties {
+
+    private JwtConfig jwt = new JwtConfig();
+    private RateLimitConfig rateLimit = new RateLimitConfig();
+    private CorsConfig cors = new CorsConfig();
+    private List<String> publicPaths = new ArrayList<>();
+
+    @Getter
+    @Setter
+    public static class JwtConfig {
+        private String secret;
+        private String issuer = "mangala";
+        private long accessTokenExpiration = 900000; // 15 minutes
+        private long refreshTokenExpiration = 604800000; // 7 days
+    }
+
+    @Getter
+    @Setter
+    public static class RateLimitConfig {
+        private boolean enabled = true;
+        private int defaultReplenishRate = 10;
+        private int defaultBurstCapacity = 20;
+        private int requestedTokens = 1;
+    }
+
+    @Getter
+    @Setter
+    public static class CorsConfig {
+        private List<String> allowedOrigins = new ArrayList<>();
+        private List<String> allowedMethods = List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH");
+        private List<String> allowedHeaders = List.of("*");
+        private List<String> exposedHeaders = List.of("X-Request-Id", "X-Correlation-Id");
+        private boolean allowCredentials = true;
+        private long maxAge = 3600;
+    }
+}

--- a/src/main/java/org/mangala/gateway/config/RateLimiterConfig.java
+++ b/src/main/java/org/mangala/gateway/config/RateLimiterConfig.java
@@ -1,0 +1,36 @@
+package org.mangala.gateway.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+@Configuration
+public class RateLimiterConfig {
+
+    @Bean
+    public KeyResolver ipKeyResolver() {
+        return exchange -> {
+            String clientIp = Objects.requireNonNull(exchange.getRequest().getRemoteAddress())
+                    .getAddress()
+                    .getHostAddress();
+            return Mono.just(clientIp);
+        };
+    }
+
+    @Bean
+    public KeyResolver userKeyResolver() {
+        return exchange -> {
+            String userId = exchange.getRequest().getHeaders().getFirst("X-User-Id");
+            if (userId != null && !userId.isEmpty()) {
+                return Mono.just(userId);
+            }
+            String clientIp = Objects.requireNonNull(exchange.getRequest().getRemoteAddress())
+                    .getAddress()
+                    .getHostAddress();
+            return Mono.just(clientIp);
+        };
+    }
+}

--- a/src/main/java/org/mangala/gateway/config/RateLimiterConfig.java
+++ b/src/main/java/org/mangala/gateway/config/RateLimiterConfig.java
@@ -3,6 +3,7 @@ package org.mangala.gateway.config;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
@@ -31,6 +32,21 @@ public class RateLimiterConfig {
                     .getAddress()
                     .getHostAddress();
             return Mono.just(clientIp);
+        };
+    }
+
+    @Bean
+    @Primary
+    public KeyResolver compositeKeyResolver() {
+        return exchange -> {
+            String clientIp = Objects.requireNonNull(exchange.getRequest().getRemoteAddress())
+                    .getAddress()
+                    .getHostAddress();
+            String userId = exchange.getRequest().getHeaders().getFirst("X-User-Id");
+            String userPart = (userId != null && !userId.isEmpty()) ? userId : "anonymous";
+
+            // Compose key as "ip:user" with requested order: ip first, user second.
+            return Mono.just(clientIp + ":" + userPart);
         };
     }
 }

--- a/src/main/java/org/mangala/gateway/config/SecurityConfig.java
+++ b/src/main/java/org/mangala/gateway/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package org.mangala.gateway.config;
+
+import lombok.RequiredArgsConstructor;
+import org.mangala.gateway.filter.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+
+@Configuration
+@EnableWebFluxSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final GatewayConfigProperties gatewayConfigProperties;
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+                .authorizeExchange(exchanges -> exchanges
+                        // Public endpoints - no authentication required
+                        .pathMatchers(HttpMethod.OPTIONS).permitAll()
+                        .pathMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .pathMatchers("/fallback/**").permitAll()
+                        .pathMatchers("/api/v1/register/**").permitAll()
+                        .pathMatchers("/api/v1/authenticate/**").permitAll()
+                        .pathMatchers("/api/v1/auth/refresh").permitAll()
+                        // All other requests require authentication
+                        .anyExchange().authenticated()
+                )
+                .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/exception/GatewayErrorResponse.java
+++ b/src/main/java/org/mangala/gateway/exception/GatewayErrorResponse.java
@@ -1,0 +1,34 @@
+package org.mangala.gateway.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GatewayErrorResponse {
+
+    private String code;
+    private String message;
+    private String path;
+    private String requestId;
+    private Instant timestamp;
+    private Object details;
+
+    public static GatewayErrorResponse of(String code, String message, String path, String requestId) {
+        return GatewayErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .path(path)
+                .requestId(requestId)
+                .timestamp(Instant.now())
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/mangala/gateway/exception/GlobalExceptionHandler.java
@@ -1,0 +1,84 @@
+package org.mangala.gateway.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.ConnectException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+@Order(-2)
+@Component
+@RequiredArgsConstructor
+public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        ServerHttpResponse response = exchange.getResponse();
+
+        String path = exchange.getRequest().getPath().value();
+        String requestId = exchange.getRequest().getHeaders().getFirst("X-Request-Id");
+
+        HttpStatus status;
+        String code;
+        String message;
+
+        if (ex instanceof ResponseStatusException rse) {
+            status = HttpStatus.valueOf(rse.getStatusCode().value());
+            code = "GATEWAY_" + status.name();
+            message = rse.getReason() != null ? rse.getReason() : status.getReasonPhrase();
+        } else if (ex instanceof ConnectException) {
+            status = HttpStatus.SERVICE_UNAVAILABLE;
+            code = "SERVICE_UNAVAILABLE";
+            message = "Downstream service is unavailable";
+            log.error("[{}] Service unavailable for path {}: {}", requestId, path, ex.getMessage());
+        } else if (ex instanceof TimeoutException) {
+            status = HttpStatus.GATEWAY_TIMEOUT;
+            code = "GATEWAY_TIMEOUT";
+            message = "Request timed out";
+            log.error("[{}] Timeout for path {}: {}", requestId, path, ex.getMessage());
+        } else if (ex.getCause() instanceof ConnectException) {
+            status = HttpStatus.SERVICE_UNAVAILABLE;
+            code = "SERVICE_UNAVAILABLE";
+            message = "Downstream service is unavailable";
+            log.error("[{}] Service unavailable for path {}: {}", requestId, path, ex.getMessage());
+        } else {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+            code = "INTERNAL_ERROR";
+            message = "An unexpected error occurred";
+            log.error("[{}] Unexpected error for path {}: ", requestId, path, ex);
+        }
+
+        GatewayErrorResponse errorResponse = GatewayErrorResponse.of(code, message, path, requestId);
+
+        response.setStatusCode(status);
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+            DataBuffer buffer = response.bufferFactory().wrap(bytes);
+            return response.writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing error response", e);
+            byte[] fallback = "{\"code\":\"INTERNAL_ERROR\",\"message\":\"Error processing request\"}"
+                    .getBytes(StandardCharsets.UTF_8);
+            DataBuffer buffer = response.bufferFactory().wrap(fallback);
+            return response.writeWith(Mono.just(buffer));
+        }
+    }
+}

--- a/src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
@@ -8,10 +8,13 @@ import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mangala.gateway.config.GatewayConfigProperties;
+import org.mangala.security.SecurityConstants;
+import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -24,21 +27,22 @@ import reactor.core.publisher.Mono;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter implements WebFilter {
-
-    private static final String BEARER_PREFIX = "Bearer ";
-    private static final String USER_ID_HEADER = "X-User-Id";
-    private static final String USER_EMAIL_HEADER = "X-User-Email";
-    private static final String USER_ROLES_HEADER = "X-User-Roles";
+public class JwtAuthenticationFilter implements WebFilter, Ordered {
 
     private final GatewayConfigProperties gatewayConfigProperties;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    public int getOrder() {
+        // Run before AbacAuthorizationFilter
+        return Ordered.LOWEST_PRECEDENCE - 20;
+    }
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
@@ -52,38 +56,66 @@ public class JwtAuthenticationFilter implements WebFilter {
 
         String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
 
-        if (!StringUtils.hasText(authHeader) || !authHeader.startsWith(BEARER_PREFIX)) {
+        if (!StringUtils.hasText(authHeader) || !authHeader.startsWith(SecurityConstants.BEARER_PREFIX)) {
             return chain.filter(exchange);
         }
 
-        String token = authHeader.substring(BEARER_PREFIX.length());
+        String token = authHeader.substring(SecurityConstants.BEARER_PREFIX.length());
 
         try {
             Claims claims = validateToken(token);
             String userId = claims.getSubject();
-            String email = claims.get("email", String.class);
+            String email = claims.get(SecurityConstants.CLAIM_EMAIL, String.class);
 
             @SuppressWarnings("unchecked")
-            List<String> roles = claims.get("roles", List.class);
+            List<String> roles = claims.get(SecurityConstants.CLAIM_ROLES, List.class);
+
+            @SuppressWarnings("unchecked")
+            List<String> permissions = claims.get(SecurityConstants.CLAIM_PERMISSIONS, List.class);
 
             // Add user info to request headers for downstream services
-            ServerHttpRequest mutatedRequest = request.mutate()
-                    .header(USER_ID_HEADER, userId)
-                    .header(USER_EMAIL_HEADER, email != null ? email : "")
-                    .header(USER_ROLES_HEADER, roles != null ? String.join(",", roles) : "")
-                    .build();
+            ServerHttpRequest.Builder requestBuilder = request.mutate()
+                    .header(SecurityConstants.HEADER_USER_ID, userId)
+                    .header(SecurityConstants.HEADER_USER_EMAIL, email != null ? email : "")
+                    .header(SecurityConstants.HEADER_USER_ROLES, roles != null ? String.join(",", roles) : "");
+
+            // Add permissions header if present
+            if (permissions != null && !permissions.isEmpty()) {
+                requestBuilder.header(SecurityConstants.HEADER_USER_PERMISSIONS, String.join(",", permissions));
+            }
+
+            ServerHttpRequest mutatedRequest = requestBuilder.build();
 
             ServerWebExchange mutatedExchange = exchange.mutate()
                     .request(mutatedRequest)
                     .build();
 
-            // Create authentication object
-            List<SimpleGrantedAuthority> authorities = roles != null
-                    ? roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList())
-                    : List.of();
+            // Create authentication object with both roles and permissions as authorities
+            List<GrantedAuthority> authorities = new ArrayList<>();
+
+            // Add roles as authorities
+            if (roles != null) {
+                roles.stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .forEach(authorities::add);
+            }
+
+            // Add permissions as authorities (for AbacAuthorizationFilter)
+            if (permissions != null) {
+                permissions.stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .forEach(authorities::add);
+            }
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+            // Store permissions in authentication details for AbacAuthorizationFilter
+            Map<String, Object> details = new HashMap<>();
+            details.put("email", email);
+            details.put("roles", roles != null ? new HashSet<>(roles) : Collections.emptySet());
+            details.put("permissions", permissions != null ? new HashSet<>(permissions) : Collections.emptySet());
+            authentication.setDetails(details);
 
             return chain.filter(mutatedExchange)
                     .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));

--- a/src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,119 @@
+package org.mangala.gateway.filter;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.gateway.config.GatewayConfigProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_EMAIL_HEADER = "X-User-Email";
+    private static final String USER_ROLES_HEADER = "X-User-Roles";
+
+    private final GatewayConfigProperties gatewayConfigProperties;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        String path = request.getPath().value();
+
+        // Skip authentication for public paths
+        if (isPublicPath(path)) {
+            return chain.filter(exchange);
+        }
+
+        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (!StringUtils.hasText(authHeader) || !authHeader.startsWith(BEARER_PREFIX)) {
+            return chain.filter(exchange);
+        }
+
+        String token = authHeader.substring(BEARER_PREFIX.length());
+
+        try {
+            Claims claims = validateToken(token);
+            String userId = claims.getSubject();
+            String email = claims.get("email", String.class);
+
+            @SuppressWarnings("unchecked")
+            List<String> roles = claims.get("roles", List.class);
+
+            // Add user info to request headers for downstream services
+            ServerHttpRequest mutatedRequest = request.mutate()
+                    .header(USER_ID_HEADER, userId)
+                    .header(USER_EMAIL_HEADER, email != null ? email : "")
+                    .header(USER_ROLES_HEADER, roles != null ? String.join(",", roles) : "")
+                    .build();
+
+            ServerWebExchange mutatedExchange = exchange.mutate()
+                    .request(mutatedRequest)
+                    .build();
+
+            // Create authentication object
+            List<SimpleGrantedAuthority> authorities = roles != null
+                    ? roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList())
+                    : List.of();
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+            return chain.filter(mutatedExchange)
+                    .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT token expired for path: {}", path);
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        } catch (JwtException e) {
+            log.warn("Invalid JWT token for path: {}: {}", path, e.getMessage());
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+    }
+
+    private boolean isPublicPath(String path) {
+        return gatewayConfigProperties.getPublicPaths().stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    private Claims validateToken(String token) {
+        SecretKey key = Keys.hmacShaKeyFor(
+                gatewayConfigProperties.getJwt().getSecret().getBytes(StandardCharsets.UTF_8)
+        );
+
+        return Jwts.parser()
+                .verifyWith(key)
+                .requireIssuer(gatewayConfigProperties.getJwt().getIssuer())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/mangala/gateway/filter/RequestLoggingFilter.java
+++ b/src/main/java/org/mangala/gateway/filter/RequestLoggingFilter.java
@@ -1,0 +1,85 @@
+package org.mangala.gateway.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class RequestLoggingFilter implements GlobalFilter, Ordered {
+
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+    private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+    private static final String START_TIME_ATTR = "startTime";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+
+        // Generate or use existing request ID
+        String requestId = request.getHeaders().getFirst(REQUEST_ID_HEADER);
+        if (requestId == null || requestId.isEmpty()) {
+            requestId = UUID.randomUUID().toString();
+        }
+
+        // Generate or use existing correlation ID
+        String correlationId = request.getHeaders().getFirst(CORRELATION_ID_HEADER);
+        if (correlationId == null || correlationId.isEmpty()) {
+            correlationId = UUID.randomUUID().toString();
+        }
+
+        final String finalRequestId = requestId;
+        final String finalCorrelationId = correlationId;
+
+        // Add headers to request for downstream services
+        ServerHttpRequest mutatedRequest = request.mutate()
+                .header(REQUEST_ID_HEADER, requestId)
+                .header(CORRELATION_ID_HEADER, correlationId)
+                .build();
+
+        ServerWebExchange mutatedExchange = exchange.mutate()
+                .request(mutatedRequest)
+                .build();
+
+        // Store start time for response time calculation
+        mutatedExchange.getAttributes().put(START_TIME_ATTR, System.currentTimeMillis());
+
+        log.info("[{}] Incoming request: {} {} from {}",
+                finalRequestId,
+                request.getMethod(),
+                request.getPath(),
+                request.getRemoteAddress());
+
+        return chain.filter(mutatedExchange)
+                .then(Mono.fromRunnable(() -> {
+                    Long startTime = mutatedExchange.getAttribute(START_TIME_ATTR);
+                    ServerHttpResponse response = mutatedExchange.getResponse();
+
+                    // Add tracing headers to response
+                    response.getHeaders().add(REQUEST_ID_HEADER, finalRequestId);
+                    response.getHeaders().add(CORRELATION_ID_HEADER, finalCorrelationId);
+
+                    long duration = startTime != null ? System.currentTimeMillis() - startTime : 0;
+
+                    log.info("[{}] Response: {} {} - Status: {} - Duration: {}ms",
+                            finalRequestId,
+                            request.getMethod(),
+                            request.getPath(),
+                            response.getStatusCode(),
+                            duration);
+                }));
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/src/main/java/org/mangala/gateway/health/FallbackController.java
+++ b/src/main/java/org/mangala/gateway/health/FallbackController.java
@@ -1,0 +1,87 @@
+package org.mangala.gateway.health;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.gateway.exception.GatewayErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RestController
+@RequestMapping("/fallback")
+public class FallbackController {
+
+    @GetMapping
+    public Mono<ResponseEntity<GatewayErrorResponse>> defaultFallback(
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId) {
+        log.warn("[{}] Circuit breaker fallback triggered", requestId);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(GatewayErrorResponse.of(
+                        "SERVICE_UNAVAILABLE",
+                        "Service is temporarily unavailable. Please try again later.",
+                        "/fallback",
+                        requestId
+                )));
+    }
+
+    @GetMapping("/auth")
+    public Mono<ResponseEntity<GatewayErrorResponse>> authFallback(
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId) {
+        log.warn("[{}] Auth service circuit breaker fallback triggered", requestId);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(GatewayErrorResponse.of(
+                        "AUTH_SERVICE_UNAVAILABLE",
+                        "Authentication service is temporarily unavailable. Please try again later.",
+                        "/fallback/auth",
+                        requestId
+                )));
+    }
+
+    @GetMapping("/wallet")
+    public Mono<ResponseEntity<GatewayErrorResponse>> walletFallback(
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId) {
+        log.warn("[{}] Wallet service circuit breaker fallback triggered", requestId);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(GatewayErrorResponse.of(
+                        "WALLET_SERVICE_UNAVAILABLE",
+                        "Wallet service is temporarily unavailable. Please try again later.",
+                        "/fallback/wallet",
+                        requestId
+                )));
+    }
+
+    @GetMapping("/portfolio")
+    public Mono<ResponseEntity<GatewayErrorResponse>> portfolioFallback(
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId) {
+        log.warn("[{}] Portfolio service circuit breaker fallback triggered", requestId);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(GatewayErrorResponse.of(
+                        "PORTFOLIO_SERVICE_UNAVAILABLE",
+                        "Portfolio service is temporarily unavailable. Please try again later.",
+                        "/fallback/portfolio",
+                        requestId
+                )));
+    }
+
+    @GetMapping("/transaction")
+    public Mono<ResponseEntity<GatewayErrorResponse>> transactionFallback(
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId) {
+        log.warn("[{}] Transaction service circuit breaker fallback triggered", requestId);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(GatewayErrorResponse.of(
+                        "TRANSACTION_SERVICE_UNAVAILABLE",
+                        "Transaction service is temporarily unavailable. Please try again later.",
+                        "/fallback/transaction",
+                        requestId
+                )));
+    }
+}

--- a/src/main/java/org/mangala/gateway/health/GatewayHealthIndicator.java
+++ b/src/main/java/org/mangala/gateway/health/GatewayHealthIndicator.java
@@ -1,0 +1,28 @@
+package org.mangala.gateway.health;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class GatewayHealthIndicator implements ReactiveHealthIndicator {
+
+    private final RouteLocator routeLocator;
+
+    @Override
+    public Mono<Health> health() {
+        return routeLocator.getRoutes()
+                .count()
+                .map(count -> Health.up()
+                        .withDetail("routes", count)
+                        .withDetail("status", "Gateway is operational")
+                        .build())
+                .onErrorResume(ex -> Mono.just(Health.down()
+                        .withDetail("error", ex.getMessage())
+                        .build()));
+    }
+}

--- a/src/main/java/org/mangala/gateway/health/PolicyCacheHealthIndicator.java
+++ b/src/main/java/org/mangala/gateway/health/PolicyCacheHealthIndicator.java
@@ -1,0 +1,54 @@
+package org.mangala.gateway.health;
+
+import lombok.RequiredArgsConstructor;
+import org.mangala.gateway.policy.PolicyCache;
+import org.mangala.gateway.policy.PolicyConfigProperties;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Health indicator for policy cache status.
+ */
+@Component
+@RequiredArgsConstructor
+public class PolicyCacheHealthIndicator implements HealthIndicator {
+
+    private final PolicyCache policyCache;
+    private final PolicyConfigProperties policyConfig;
+
+    private static final long STALE_THRESHOLD_MS = 300_000; // 5 minutes
+
+    @Override
+    public Health health() {
+        if (!policyConfig.isIncludeInHealthCheck()) {
+            return Health.up()
+                    .withDetail("status", "Not included in health check")
+                    .build();
+        }
+
+        if (!policyCache.isHealthy()) {
+            return Health.down()
+                    .withDetail("status", "Policy cache is not healthy")
+                    .withDetail("totalRules", policyCache.getTotalRules())
+                    .withDetail("version", policyCache.getVersion().get())
+                    .build();
+        }
+
+        long staleDuration = System.currentTimeMillis() - policyCache.getLastLoadTimestamp();
+        boolean isStale = staleDuration > STALE_THRESHOLD_MS;
+
+        Health.Builder builder = isStale ? Health.status("DEGRADED") : Health.up();
+
+        return builder
+                .withDetail("status", isStale ? "Cache may be stale" : "Healthy")
+                .withDetail("totalRules", policyCache.getTotalRules())
+                .withDetail("version", policyCache.getVersion().get())
+                .withDetail("lastLoadTime", Instant.ofEpochMilli(policyCache.getLastLoadTimestamp()).toString())
+                .withDetail("staleDuration", Duration.ofMillis(staleDuration).toString())
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/health/PolicyLoaderHealthContributor.java
+++ b/src/main/java/org/mangala/gateway/health/PolicyLoaderHealthContributor.java
@@ -1,0 +1,41 @@
+package org.mangala.gateway.health;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health indicator for PolicyLoader circuit breaker.
+ * Reports circuit breaker state and metrics to /actuator/health endpoint.
+ */
+@Component("policyLoaderHealth")
+@RequiredArgsConstructor
+public class PolicyLoaderHealthContributor implements HealthIndicator {
+
+    private final CircuitBreaker policyLoaderCircuitBreaker;
+
+    @Override
+    public Health health() {
+        CircuitBreaker.State state = policyLoaderCircuitBreaker.getState();
+        CircuitBreaker.Metrics metrics = policyLoaderCircuitBreaker.getMetrics();
+
+        Health.Builder builder = switch (state) {
+            case CLOSED -> Health.up();
+            case HALF_OPEN -> Health.status("DEGRADED");
+            case OPEN, DISABLED, FORCED_OPEN -> Health.down();
+            case METRICS_ONLY -> Health.unknown();
+        };
+
+        return builder
+                .withDetail("circuitBreakerState", state.name())
+                .withDetail("failureRate", String.format("%.2f%%", metrics.getFailureRate()))
+                .withDetail("slowCallRate", String.format("%.2f%%", metrics.getSlowCallRate()))
+                .withDetail("successfulCalls", metrics.getNumberOfSuccessfulCalls())
+                .withDetail("failedCalls", metrics.getNumberOfFailedCalls())
+                .withDetail("notPermittedCalls", metrics.getNumberOfNotPermittedCalls())
+                .withDetail("bufferedCalls", metrics.getNumberOfBufferedCalls())
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyCache.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyCache.java
@@ -1,0 +1,241 @@
+package org.mangala.gateway.policy;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.mangala.security.model.PolicyRule;
+import org.mangala.security.util.PermissionMatcher;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory cache for policy rules.
+ * Loaded from database at startup and refreshed on policy update events.
+ *
+ * Thread-safe implementation using ConcurrentHashMap and CopyOnWriteArrayList.
+ */
+@Slf4j
+@Component
+public class PolicyCache {
+
+    // Exact match cache: "METHOD:path" -> PolicyRule
+    private final ConcurrentHashMap<String, PolicyRule> exactMatchRules = new ConcurrentHashMap<>();
+
+    // Pattern match rules (for wildcards and path variables)
+    private final CopyOnWriteArrayList<PolicyRule> patternRules = new CopyOnWriteArrayList<>();
+
+    // Current policy version
+    @Getter
+    private final AtomicLong version = new AtomicLong(0);
+
+    // Cache health status
+    @Getter
+    private volatile boolean healthy = false;
+
+    private volatile long lastLoadTimestamp = 0;
+
+    /**
+     * Load policies from database into cache.
+     * This performs an atomic swap to avoid inconsistent reads during reload.
+     *
+     * @param permissions List of API permissions from database
+     */
+    public synchronized void loadFromDatabase(List<ApiPermissionDTO> permissions) {
+        log.info("Loading {} policy rules into cache...", permissions.size());
+        long startTime = System.currentTimeMillis();
+
+        // Group by method:path to consolidate permissions
+        Map<String, PolicyRule> newExactRules = new HashMap<>();
+        List<PolicyRule> newPatternRules = new ArrayList<>();
+
+        // Group permissions by endpoint
+        Map<String, List<ApiPermissionDTO>> groupedByEndpoint = permissions.stream()
+                .filter(ApiPermissionDTO::isActive)
+                .collect(Collectors.groupingBy(p -> p.getHttpMethod() + ":" + p.getPathPattern()));
+
+        for (Map.Entry<String, List<ApiPermissionDTO>> entry : groupedByEndpoint.entrySet()) {
+            List<ApiPermissionDTO> perms = entry.getValue();
+            ApiPermissionDTO first = perms.get(0);
+
+            // Collect all required permissions for this endpoint
+            Set<String> requiredPermissions = perms.stream()
+                    .map(ApiPermissionDTO::getPermissionCode)
+                    .collect(Collectors.toSet());
+
+            // Compile path pattern
+            Pattern compiledPattern = PermissionMatcher.compilePathPattern(first.getPathPattern());
+
+            PolicyRule rule = PolicyRule.builder()
+                    .id(first.getId())
+                    .httpMethod(first.getHttpMethod())
+                    .pathPattern(first.getPathPattern())
+                    .requiredPermissions(requiredPermissions)
+                    .conditionExpr(first.getConditionExpr())
+                    .serviceName(first.getServiceName())
+                    .priority(first.getPriority())
+                    .compiledPattern(compiledPattern)
+                    .build();
+
+            // Categorize as exact match or pattern match
+            if (isExactMatchPattern(first.getPathPattern())) {
+                newExactRules.put(entry.getKey(), rule);
+            } else {
+                newPatternRules.add(rule);
+            }
+        }
+
+        // Sort pattern rules by priority (higher first) and specificity
+        newPatternRules.sort((a, b) -> {
+            int priorityCompare = Integer.compare(b.getPriority(), a.getPriority());
+            if (priorityCompare != 0) return priorityCompare;
+            // More specific patterns (longer) come first
+            return Integer.compare(b.getPathPattern().length(), a.getPathPattern().length());
+        });
+
+        // Atomic swap
+        exactMatchRules.clear();
+        exactMatchRules.putAll(newExactRules);
+
+        patternRules.clear();
+        patternRules.addAll(newPatternRules);
+
+        lastLoadTimestamp = System.currentTimeMillis();
+        healthy = true;
+
+        log.info("Policy cache loaded successfully. Exact rules: {}, Pattern rules: {}. Time: {}ms",
+                exactMatchRules.size(), patternRules.size(), System.currentTimeMillis() - startTime);
+    }
+
+    /**
+     * Find matching policy rule for a request.
+     *
+     * @param method HTTP method
+     * @param path   Request path (should be normalized)
+     * @return Optional containing matching PolicyRule
+     */
+    public Optional<PolicyRule> findMatchingRule(String method, String path) {
+        if (!healthy) {
+            log.warn("Policy cache is not healthy, returning empty");
+            return Optional.empty();
+        }
+
+        // 1. Try exact match with specific method
+        String exactKey = method + ":" + path;
+        PolicyRule exactRule = exactMatchRules.get(exactKey);
+        if (exactRule != null) {
+            return Optional.of(exactRule);
+        }
+
+        // 2. Try exact match with wildcard method
+        String wildcardKey = "*:" + path;
+        PolicyRule wildcardRule = exactMatchRules.get(wildcardKey);
+        if (wildcardRule != null) {
+            return Optional.of(wildcardRule);
+        }
+
+        // 3. Try pattern matching (already sorted by priority)
+        for (PolicyRule rule : patternRules) {
+            if (matchesRule(rule, method, path)) {
+                return Optional.of(rule);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Find all matching rules for a request (for audit/debug purposes).
+     *
+     * @param method HTTP method
+     * @param path   Request path
+     * @return List of all matching rules
+     */
+    public List<PolicyRule> findAllMatchingRules(String method, String path) {
+        List<PolicyRule> matches = new ArrayList<>();
+
+        // Check exact matches
+        String exactKey = method + ":" + path;
+        PolicyRule exactRule = exactMatchRules.get(exactKey);
+        if (exactRule != null) {
+            matches.add(exactRule);
+        }
+
+        String wildcardKey = "*:" + path;
+        PolicyRule wildcardRule = exactMatchRules.get(wildcardKey);
+        if (wildcardRule != null) {
+            matches.add(wildcardRule);
+        }
+
+        // Check pattern matches
+        for (PolicyRule rule : patternRules) {
+            if (matchesRule(rule, method, path)) {
+                matches.add(rule);
+            }
+        }
+
+        return matches;
+    }
+
+    /**
+     * Update policy version.
+     *
+     * @param newVersion New version number
+     */
+    public void setVersion(long newVersion) {
+        version.set(newVersion);
+    }
+
+    /**
+     * Get last successful load timestamp.
+     */
+    public long getLastLoadTimestamp() {
+        return lastLoadTimestamp;
+    }
+
+    /**
+     * Get total number of cached rules.
+     */
+    public int getTotalRules() {
+        return exactMatchRules.size() + patternRules.size();
+    }
+
+    /**
+     * Mark cache as unhealthy (e.g., on load failure).
+     */
+    public void markUnhealthy() {
+        this.healthy = false;
+    }
+
+    /**
+     * Clear all cached rules.
+     */
+    public synchronized void clear() {
+        exactMatchRules.clear();
+        patternRules.clear();
+        healthy = false;
+        log.info("Policy cache cleared");
+    }
+
+    private boolean isExactMatchPattern(String pathPattern) {
+        // Exact match if no wildcards or path variables
+        return !pathPattern.contains("*") &&
+                !pathPattern.contains("{") &&
+                !pathPattern.contains("}");
+    }
+
+    private boolean matchesRule(PolicyRule rule, String method, String path) {
+        // Check method
+        if (!PermissionMatcher.matchesMethod(rule.getHttpMethod(), method)) {
+            return false;
+        }
+
+        // Check path pattern
+        return PermissionMatcher.matchesPath(rule.getCompiledPattern(), path);
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyConfigProperties.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyConfigProperties.java
@@ -1,0 +1,68 @@
+package org.mangala.gateway.policy;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for policy cache and loading.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "gateway.policy")
+public class PolicyConfigProperties {
+
+    /**
+     * Auth Service URL for loading policies.
+     */
+    private String authServiceUrl = "http://localhost:8080";
+
+    /**
+     * Timeout for initial policy load at startup (seconds).
+     */
+    private long initialLoadTimeoutSeconds = 30;
+
+    /**
+     * Interval to check policy version for updates (seconds).
+     */
+    private long versionCheckIntervalSeconds = 60;
+
+    /**
+     * Whether to fail startup if initial policy load fails.
+     */
+    private boolean failOnLoadError = true;
+
+    /**
+     * Redis channel for policy update broadcasts.
+     */
+    private String redisChannel = "policy:updates";
+
+    /**
+     * Kafka topic for policy update broadcasts (if using Kafka).
+     */
+    private String kafkaTopic = "policy-updates";
+
+    /**
+     * Whether to use Kafka for policy updates (false = use Redis).
+     */
+    private boolean useKafka = false;
+
+    /**
+     * Whether policy cache health affects gateway health.
+     */
+    private boolean includeInHealthCheck = true;
+
+    /**
+     * Default behavior when no policy rule matches.
+     * DENY = block request (secure default)
+     * ALLOW = allow request (permissive, for development)
+     */
+    private NoMatchBehavior noMatchBehavior = NoMatchBehavior.DENY;
+
+    public enum NoMatchBehavior {
+        DENY,
+        ALLOW
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyLoader.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyLoader.java
@@ -3,7 +3,7 @@ package org.mangala.gateway.policy;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
-import io.github.resilience4j.reactor.timelimiter.operator.TimeLimiterOperator;
+import io.github.resilience4j.reactor.timelimiter.TimeLimiterOperator;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +19,7 @@ import reactor.util.retry.Retry;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Loads policy rules from Auth Service at gateway startup.
@@ -37,6 +38,7 @@ public class PolicyLoader implements ApplicationRunner {
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final CircuitBreaker policyLoaderCircuitBreaker;
     private final TimeLimiter policyLoaderTimeLimiter;
+    private final AtomicBoolean loadInProgress = new AtomicBoolean(false);
 
     private static final String POLICY_VERSION_KEY = "policy:version";
 
@@ -53,6 +55,11 @@ public class PolicyLoader implements ApplicationRunner {
      * Load all policies from Auth Service with circuit breaker protection.
      */
     public Mono<Void> loadPolicies() {
+        if (!loadInProgress.compareAndSet(false, true)) {
+            log.info("Policy load already in progress, skipping duplicate trigger");
+            return Mono.empty();
+        }
+
         log.info("Loading policies from Auth Service: {}", policyConfig.getAuthServiceUrl());
 
         WebClient client = webClientBuilder
@@ -60,7 +67,7 @@ public class PolicyLoader implements ApplicationRunner {
                 .build();
 
         return client.get()
-                .uri("/internal/policies")
+                .uri("/v1/internal/policies")
                 .retrieve()
                 .bodyToFlux(ApiPermissionDTO.class)
                 .collectList()
@@ -76,6 +83,7 @@ public class PolicyLoader implements ApplicationRunner {
                 .flatMap(this::loadPoliciesAndVersion)
                 // Fallback when circuit breaker is open or call fails
                 .onErrorResume(this::handleLoadError)
+                .doFinally(signal -> loadInProgress.set(false))
                 .then();
     }
 
@@ -186,7 +194,7 @@ public class PolicyLoader implements ApplicationRunner {
                 .build();
 
         return client.get()
-                .uri("/internal/policies/version")
+                .uri("/v1/internal/policies/version")
                 .retrieve()
                 .bodyToMono(Long.class)
                 // Apply circuit breaker to version fetch as well

--- a/src/main/java/org/mangala/gateway/policy/PolicyLoader.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyLoader.java
@@ -1,0 +1,202 @@
+package org.mangala.gateway.policy;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.reactor.timelimiter.operator.TimeLimiterOperator;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Loads policy rules from Auth Service at gateway startup.
+ * Protected by circuit breaker for resilience.
+ * Also provides methods for manual reload.
+ */
+@Slf4j
+@Component
+@Order(1)
+@RequiredArgsConstructor
+public class PolicyLoader implements ApplicationRunner {
+
+    private final PolicyCache policyCache;
+    private final PolicyConfigProperties policyConfig;
+    private final WebClient.Builder webClientBuilder;
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final CircuitBreaker policyLoaderCircuitBreaker;
+    private final TimeLimiter policyLoaderTimeLimiter;
+
+    private static final String POLICY_VERSION_KEY = "policy:version";
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Starting policy loader...");
+        loadPolicies()
+                .doOnSuccess(v -> log.info("Initial policy load completed successfully"))
+                .doOnError(e -> log.error("Initial policy load failed", e))
+                .block(Duration.ofSeconds(policyConfig.getInitialLoadTimeoutSeconds()));
+    }
+
+    /**
+     * Load all policies from Auth Service with circuit breaker protection.
+     */
+    public Mono<Void> loadPolicies() {
+        log.info("Loading policies from Auth Service: {}", policyConfig.getAuthServiceUrl());
+
+        WebClient client = webClientBuilder
+                .baseUrl(policyConfig.getAuthServiceUrl())
+                .build();
+
+        return client.get()
+                .uri("/internal/policies")
+                .retrieve()
+                .bodyToFlux(ApiPermissionDTO.class)
+                .collectList()
+                // Apply time limiter first, then circuit breaker
+                .transformDeferred(TimeLimiterOperator.of(policyLoaderTimeLimiter))
+                .transformDeferred(CircuitBreakerOperator.of(policyLoaderCircuitBreaker))
+                // Retry with backoff (only for retryable errors)
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1))
+                        .maxBackoff(Duration.ofSeconds(10))
+                        .filter(this::isRetryableError)
+                        .doBeforeRetry(signal -> log.warn("Retrying policy load, attempt: {}",
+                                signal.totalRetries() + 1)))
+                .flatMap(this::loadPoliciesAndVersion)
+                // Fallback when circuit breaker is open or call fails
+                .onErrorResume(this::handleLoadError)
+                .then();
+    }
+
+    /**
+     * Reload policies if version has changed.
+     */
+    public Mono<Boolean> reloadIfVersionChanged() {
+        return fetchRemoteVersion()
+                .flatMap(remoteVersion -> {
+                    long currentVersion = policyCache.getVersion().get();
+                    if (remoteVersion > currentVersion) {
+                        log.info("Policy version changed: {} -> {}. Reloading...", currentVersion, remoteVersion);
+                        return loadPolicies().thenReturn(true);
+                    }
+                    return Mono.just(false);
+                })
+                .onErrorResume(e -> {
+                    log.warn("Failed to check policy version", e);
+                    return Mono.just(false);
+                });
+    }
+
+    /**
+     * Force reload policies regardless of version.
+     */
+    public Mono<Void> forceReload() {
+        log.info("Force reloading policies...");
+        return loadPolicies();
+    }
+
+    /**
+     * Get circuit breaker state for health checks.
+     */
+    public CircuitBreaker.State getCircuitBreakerState() {
+        return policyLoaderCircuitBreaker.getState();
+    }
+
+    /**
+     * Check if circuit breaker is allowing calls.
+     */
+    public boolean isCircuitBreakerHealthy() {
+        CircuitBreaker.State state = policyLoaderCircuitBreaker.getState();
+        return state == CircuitBreaker.State.CLOSED ||
+                state == CircuitBreaker.State.HALF_OPEN;
+    }
+
+    /**
+     * Determine if an error is retryable.
+     * Circuit breaker open errors should not be retried.
+     */
+    private boolean isRetryableError(Throwable t) {
+        // Don't retry if circuit breaker is open
+        if (t instanceof CallNotPermittedException) {
+            log.debug("Circuit breaker is open, not retrying");
+            return false;
+        }
+        // Retry on network/timeout errors
+        return true;
+    }
+
+    /**
+     * Fallback handler - continues with cached policies if available.
+     */
+    private Mono<Void> handleLoadError(Throwable error) {
+        if (error instanceof CallNotPermittedException) {
+            log.warn("Policy load blocked by circuit breaker - using cached policies");
+        } else {
+            log.error("Policy load failed: {}", error.getMessage());
+        }
+
+        // If we have cached policies, continue using them
+        if (policyCache.getTotalRules() > 0) {
+            log.info("Fallback: continuing with {} cached policies", policyCache.getTotalRules());
+            return Mono.empty();
+        }
+
+        // No cached policies and load failed - mark unhealthy
+        log.error("No cached policies available and load failed - marking cache unhealthy");
+        policyCache.markUnhealthy();
+        return Mono.empty();
+    }
+
+    private Mono<Void> loadPoliciesAndVersion(List<ApiPermissionDTO> permissions) {
+        return fetchRemoteVersion()
+                .doOnNext(version -> {
+                    policyCache.loadFromDatabase(permissions);
+                    policyCache.setVersion(version);
+                    log.info("Loaded {} policies, version: {}", permissions.size(), version);
+                })
+                .then();
+    }
+
+    private Mono<Long> fetchRemoteVersion() {
+        // Try Redis first
+        return redisTemplate.opsForValue()
+                .get(POLICY_VERSION_KEY)
+                .map(Long::parseLong)
+                .switchIfEmpty(fetchVersionFromAuthService())
+                .onErrorResume(e -> {
+                    log.warn("Failed to fetch version from Redis, trying Auth Service", e);
+                    return fetchVersionFromAuthService();
+                });
+    }
+
+    private Mono<Long> fetchVersionFromAuthService() {
+        WebClient client = webClientBuilder
+                .baseUrl(policyConfig.getAuthServiceUrl())
+                .build();
+
+        return client.get()
+                .uri("/internal/policies/version")
+                .retrieve()
+                .bodyToMono(Long.class)
+                // Apply circuit breaker to version fetch as well
+                .transformDeferred(CircuitBreakerOperator.of(policyLoaderCircuitBreaker))
+                .doOnNext(v -> {
+                    // Update Redis with latest version
+                    redisTemplate.opsForValue()
+                            .set(POLICY_VERSION_KEY, v.toString(), Duration.ofMinutes(5))
+                            .subscribe();
+                })
+                .onErrorReturn(1L);
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyLoaderCircuitBreakerConfig.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyLoaderCircuitBreakerConfig.java
@@ -1,0 +1,70 @@
+package org.mangala.gateway.policy;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Circuit breaker configuration for PolicyLoader.
+ * Protects Auth Service calls during policy loading.
+ */
+@Slf4j
+@Configuration
+public class PolicyLoaderCircuitBreakerConfig {
+
+    public static final String POLICY_LOADER_CB = "policyLoaderCircuitBreaker";
+    public static final String POLICY_LOADER_TL = "policyLoaderTimeLimiter";
+
+    @Bean
+    public CircuitBreaker policyLoaderCircuitBreaker(CircuitBreakerRegistry circuitBreakerRegistry) {
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(5)
+                .minimumNumberOfCalls(3)
+                .failureRateThreshold(60)
+                .waitDurationInOpenState(Duration.ofSeconds(30))
+                .permittedNumberOfCallsInHalfOpenState(2)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .recordExceptions(Exception.class)
+                .build();
+
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(POLICY_LOADER_CB, config);
+
+        // Register event handlers for monitoring
+        circuitBreaker.getEventPublisher()
+                .onStateTransition(event ->
+                        log.info("Policy loader circuit breaker state changed: {} -> {}",
+                                event.getStateTransition().getFromState(),
+                                event.getStateTransition().getToState()))
+                .onError(event ->
+                        log.warn("Policy loader circuit breaker recorded error: {}",
+                                event.getThrowable().getMessage()))
+                .onSuccess(event -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Policy loader call succeeded in {}ms",
+                                event.getElapsedDuration().toMillis());
+                    }
+                })
+                .onCallNotPermitted(event ->
+                        log.warn("Policy loader call not permitted - circuit breaker is OPEN"));
+
+        return circuitBreaker;
+    }
+
+    @Bean
+    public TimeLimiter policyLoaderTimeLimiter() {
+        TimeLimiterConfig config = TimeLimiterConfig.custom()
+                .timeoutDuration(Duration.ofSeconds(10))
+                .cancelRunningFuture(true)
+                .build();
+
+        return TimeLimiter.of(POLICY_LOADER_TL, config);
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyUpdateListener.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyUpdateListener.java
@@ -1,0 +1,83 @@
+package org.mangala.gateway.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mangala.security.model.PolicyUpdateEvent;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+import reactor.core.Disposable;
+
+/**
+ * Listens for policy update events via Redis Pub/Sub.
+ * When an update is received, triggers policy cache reload.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PolicyUpdateListener {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final PolicyLoader policyLoader;
+    private final PolicyCache policyCache;
+    private final PolicyConfigProperties policyConfig;
+    private final ObjectMapper objectMapper;
+
+    private Disposable subscription;
+
+    @PostConstruct
+    public void subscribe() {
+        if (policyConfig.isUseKafka()) {
+            log.info("Using Kafka for policy updates, Redis listener disabled");
+            return;
+        }
+
+        String channel = policyConfig.getRedisChannel();
+        log.info("Subscribing to policy updates on Redis channel: {}", channel);
+
+        subscription = redisTemplate.listenTo(ChannelTopic.of(channel))
+                .map(ReactiveSubscription.Message::getMessage)
+                .doOnNext(this::handleUpdate)
+                .doOnError(e -> log.error("Error in policy update listener", e))
+                .retry()
+                .subscribe();
+    }
+
+    @PreDestroy
+    public void unsubscribe() {
+        if (subscription != null && !subscription.isDisposed()) {
+            subscription.dispose();
+            log.info("Unsubscribed from policy updates");
+        }
+    }
+
+    private void handleUpdate(String message) {
+        try {
+            PolicyUpdateEvent event = objectMapper.readValue(message, PolicyUpdateEvent.class);
+            log.info("Received policy update event. Version: {}, Type: {}",
+                    event.getVersion(), event.getUpdateType());
+
+            long currentVersion = policyCache.getVersion().get();
+
+            if (event.getVersion() > currentVersion) {
+                log.info("New policy version detected: {} -> {}. Reloading...",
+                        currentVersion, event.getVersion());
+
+                policyLoader.loadPolicies()
+                        .doOnSuccess(v -> log.info("Policy reload completed after broadcast"))
+                        .doOnError(e -> log.error("Policy reload failed after broadcast", e))
+                        .subscribe();
+            } else {
+                log.debug("Ignoring policy update. Current: {}, Event: {}",
+                        currentVersion, event.getVersion());
+            }
+
+        } catch (Exception e) {
+            log.error("Failed to parse policy update message: {}", message, e);
+        }
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyVersionChecker.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyVersionChecker.java
@@ -21,7 +21,10 @@ public class PolicyVersionChecker {
      * Check for policy updates every 60 seconds.
      * This is a fallback in case broadcast messages are missed.
      */
-    @Scheduled(fixedDelayString = "${gateway.policy.version-check-interval-seconds:60}000")
+    @Scheduled(
+            fixedDelayString = "${gateway.policy.version-check-interval-seconds:60}000",
+            initialDelayString = "${gateway.policy.version-check-initial-delay-seconds:15}000"
+    )
     public void checkForUpdates() {
         if (!policyCache.isHealthy()) {
             log.warn("Policy cache unhealthy, attempting reload...");

--- a/src/main/java/org/mangala/gateway/policy/PolicyVersionChecker.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyVersionChecker.java
@@ -1,0 +1,48 @@
+package org.mangala.gateway.policy;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodically checks policy version as a fallback mechanism.
+ * This ensures policies are eventually consistent even if broadcasts are missed.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PolicyVersionChecker {
+
+    private final PolicyLoader policyLoader;
+    private final PolicyCache policyCache;
+
+    /**
+     * Check for policy updates every 60 seconds.
+     * This is a fallback in case broadcast messages are missed.
+     */
+    @Scheduled(fixedDelayString = "${gateway.policy.version-check-interval-seconds:60}000")
+    public void checkForUpdates() {
+        if (!policyCache.isHealthy()) {
+            log.warn("Policy cache unhealthy, attempting reload...");
+            policyLoader.forceReload()
+                    .doOnSuccess(v -> log.info("Policy cache recovered"))
+                    .doOnError(e -> log.error("Policy cache recovery failed", e))
+                    .subscribe();
+            return;
+        }
+
+        // Check if cache is stale (not updated in 5 minutes)
+        long staleDuration = System.currentTimeMillis() - policyCache.getLastLoadTimestamp();
+        if (staleDuration > 300_000) { // 5 minutes
+            log.warn("Policy cache may be stale (last load: {}ms ago). Checking version...", staleDuration);
+        }
+
+        policyLoader.reloadIfVersionChanged()
+                .subscribe(reloaded -> {
+                    if (reloaded) {
+                        log.info("Policy cache updated via version check");
+                    }
+                });
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
               replenishRate: ${RATE_LIMIT_REPLENISH:10}
               burstCapacity: ${RATE_LIMIT_BURST:20}
               requestedTokens: 1
-            key-resolver: "#{@ipKeyResolver}"
+            key-resolver: "#{@compositeKeyResolver}"
         - name: CircuitBreaker
           args:
             name: defaultCircuitBreaker
@@ -122,6 +122,7 @@ gateway:
   policy:
     auth-service-url: ${AUTH_SERVICE_URL:http://localhost:8080}
     initial-load-timeout-seconds: ${POLICY_LOAD_TIMEOUT:30}
+    version-check-initial-delay-seconds: ${POLICY_VERSION_CHECK_INITIAL_DELAY:15}
     version-check-interval-seconds: ${POLICY_VERSION_CHECK_INTERVAL:60}
     fail-on-load-error: ${POLICY_FAIL_ON_LOAD_ERROR:true}
     redis-channel: ${POLICY_REDIS_CHANNEL:policy:updates}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,172 @@
+server:
+  port: ${SERVER_PORT:8000}
+
+spring:
+  application:
+    name: mangala-gateway
+
+  # Redis for Rate Limiting
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: 2000ms
+
+  cloud:
+    gateway:
+      # Global CORS Configuration
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOrigins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+              - OPTIONS
+              - PATCH
+            allowedHeaders: "*"
+            exposedHeaders:
+              - X-Request-Id
+              - X-Correlation-Id
+            allowCredentials: true
+            maxAge: 3600
+
+      # Default Filters (applied to all routes)
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin
+        - name: RequestRateLimiter
+          args:
+            redis-rate-limiter:
+              replenishRate: ${RATE_LIMIT_REPLENISH:10}
+              burstCapacity: ${RATE_LIMIT_BURST:20}
+              requestedTokens: 1
+            key-resolver: "#{@ipKeyResolver}"
+        - name: CircuitBreaker
+          args:
+            name: defaultCircuitBreaker
+            fallbackUri: forward:/fallback
+
+      # Route Definitions
+      routes:
+        # Authentication Service
+        - id: auth-service
+          uri: ${AUTH_SERVICE_URL:http://localhost:8080}
+          predicates:
+            - Path=/api/v1/auth/**,/api/v1/register/**,/api/v1/authenticate/**
+          filters:
+            - StripPrefix=0
+            - name: CircuitBreaker
+              args:
+                name: authServiceCircuitBreaker
+                fallbackUri: forward:/fallback/auth
+
+        # Wallet Service (future)
+        - id: wallet-service
+          uri: ${WALLET_SERVICE_URL:http://localhost:8081}
+          predicates:
+            - Path=/api/v1/wallets/**,/api/v1/addresses/**
+          filters:
+            - StripPrefix=0
+            - name: CircuitBreaker
+              args:
+                name: walletServiceCircuitBreaker
+                fallbackUri: forward:/fallback/wallet
+
+        # Portfolio Service (future)
+        - id: portfolio-service
+          uri: ${PORTFOLIO_SERVICE_URL:http://localhost:8082}
+          predicates:
+            - Path=/api/v1/portfolios/**,/api/v1/holdings/**
+          filters:
+            - StripPrefix=0
+            - name: CircuitBreaker
+              args:
+                name: portfolioServiceCircuitBreaker
+                fallbackUri: forward:/fallback/portfolio
+
+        # Transaction Service (future)
+        - id: transaction-service
+          uri: ${TRANSACTION_SERVICE_URL:http://localhost:8083}
+          predicates:
+            - Path=/api/v1/transactions/**
+          filters:
+            - StripPrefix=0
+            - name: CircuitBreaker
+              args:
+                name: transactionServiceCircuitBreaker
+                fallbackUri: forward:/fallback/transaction
+
+# Gateway Custom Configuration
+gateway:
+  jwt:
+    secret: ${JWT_SECRET:your-256-bit-secret-key-for-jwt-signing-replace-in-production}
+    issuer: ${JWT_ISSUER:mangala}
+    access-token-expiration: ${JWT_ACCESS_EXPIRATION:900000}
+    refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
+  rate-limit:
+    enabled: ${RATE_LIMIT_ENABLED:true}
+    default-replenish-rate: ${RATE_LIMIT_REPLENISH:10}
+    default-burst-capacity: ${RATE_LIMIT_BURST:20}
+  public-paths:
+    - /api/v1/register/**
+    - /api/v1/authenticate/**
+    - /api/v1/auth/refresh
+    - /actuator/health
+    - /actuator/info
+    - /fallback/**
+
+# Resilience4j Circuit Breaker Configuration
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        waitDurationInOpenState: 10s
+        failureRateThreshold: 50
+        eventConsumerBufferSize: 10
+    instances:
+      authServiceCircuitBreaker:
+        baseConfig: default
+      walletServiceCircuitBreaker:
+        baseConfig: default
+      portfolioServiceCircuitBreaker:
+        baseConfig: default
+      transactionServiceCircuitBreaker:
+        baseConfig: default
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 10s
+        cancelRunningFuture: true
+
+# Actuator Configuration
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus,gateway
+  endpoint:
+    health:
+      show-details: when_authorized
+    gateway:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+# Logging Configuration
+logging:
+  level:
+    root: INFO
+    org.mangala.gateway: DEBUG
+    org.springframework.cloud.gateway: DEBUG
+    org.springframework.security: DEBUG
+    io.github.resilience4j: DEBUG
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,6 +117,35 @@ gateway:
     - /actuator/health
     - /actuator/info
     - /fallback/**
+    - /internal/**
+  # Policy Cache Configuration
+  policy:
+    auth-service-url: ${AUTH_SERVICE_URL:http://localhost:8080}
+    initial-load-timeout-seconds: ${POLICY_LOAD_TIMEOUT:30}
+    version-check-interval-seconds: ${POLICY_VERSION_CHECK_INTERVAL:60}
+    fail-on-load-error: ${POLICY_FAIL_ON_LOAD_ERROR:true}
+    redis-channel: ${POLICY_REDIS_CHANNEL:policy:updates}
+    use-kafka: ${POLICY_USE_KAFKA:false}
+    include-in-health-check: ${POLICY_HEALTH_CHECK:true}
+    no-match-behavior: ${POLICY_NO_MATCH_BEHAVIOR:DENY}
+  # ABAC SpEL Condition Evaluation
+  abac:
+    spel:
+      enabled: ${ABAC_SPEL_ENABLED:true}
+      max-expression-length: ${ABAC_MAX_EXPR_LENGTH:500}
+      evaluation-timeout-ms: ${ABAC_EVAL_TIMEOUT:100}
+      max-cache-size: ${ABAC_CACHE_SIZE:1000}
+  # Audit Logging to Kafka
+  audit:
+    enabled: ${AUDIT_ENABLED:false}
+    kafka-bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    batch-size: ${AUDIT_BATCH_SIZE:16384}
+    linger-ms: ${AUDIT_LINGER_MS:10}
+    buffer-memory: ${AUDIT_BUFFER_MEMORY:33554432}
+    max-block-ms: ${AUDIT_MAX_BLOCK_MS:100}
+    audit-allowed-requests: ${AUDIT_ALLOWED:true}
+    audit-denied-requests: ${AUDIT_DENIED:true}
+    audit-no-policy-requests: ${AUDIT_NO_POLICY:true}
 
 # Resilience4j Circuit Breaker Configuration
 resilience4j:
@@ -139,6 +168,15 @@ resilience4j:
         baseConfig: default
       transactionServiceCircuitBreaker:
         baseConfig: default
+      # PolicyLoader circuit breaker for Auth Service policy fetching
+      policyLoaderCircuitBreaker:
+        slidingWindowSize: 5
+        minimumNumberOfCalls: 3
+        failureRateThreshold: 60
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 2
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        eventConsumerBufferSize: 10
   timelimiter:
     configs:
       default:


### PR DESCRIPTION
Summary
PR này xử lý các lỗi compile/startup trong mangala-gateway, đồng thời ổn định luồng load policy từ auth service.

What changed
Fix compile errors in mangala-common-security
Sửa PathNormalizer dùng StandardCharsets.UTF_8.name() cho [URLDecoder.decode(...)](app://-/index.html#).
Sửa AuthorizationResult static factory không phụ thuộc builder() nữa (dùng constructor trực tiếp).
Cập nhật [pom.xml](app://-/index.html#) để đồng bộ version annotation processor (Lombok).
Fix startup failure của audit publisher
AuthorizationAuditPublisher chỉ khởi tạo khi:
gateway.audit.enabled=true
Có bean ReactiveKafkaProducerTemplate
Tránh lỗi UnsatisfiedDependencyException khi chưa cấu hình Kafka producer.
Resolve ambiguous KeyResolver bean
Introduce compositeKeyResolver (ưu tiên ip, sau đó user) để dùng cho rate limiter.
Cập nhật route filter dùng:
key-resolver: "#{@compositeKeyResolver}"
Fix duplicate policy load lúc startup
Chặn concurrent load bằng guard AtomicBoolean loadInProgress trong PolicyLoader.
Thêm initial delay cho PolicyVersionChecker để tránh race với PolicyLoader.run().
Thêm config:
gateway.policy.version-check-initial-delay-seconds
Align policy endpoints with versioned internal API
Gateway gọi:
GET /v1/internal/policies
GET /v1/internal/policies/version
Add gateway knowledge/context pack + sync checks
Thêm [AGENTS.md](app://-/index.html#), ADR/context docs, script check context sync, workflow CI, và Maven profile context-check.
Why
Loại bỏ lỗi build/runtime cản trở local run.
Tránh race condition khi khởi động gây gọi policy API 2 lần.
Làm rõ chiến lược key cho rate limit khi cần nhiều nguồn định danh.
Đồng bộ gateway với versioned internal policy API từ auth.
Validation
mvn compile (gateway): pass
[pom.xml install -DskipTests && mvn compile](app://-/index.html#): pass
Context sync checks: pass