### PR TITLE
feat(gateway): harden production security headers baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ docker run -d \
 | `RATE_LIMIT_REPLENISH` | 10 | Rate limit replenish rate per second |
 | `RATE_LIMIT_BURST` | 20 | Rate limit burst capacity |
 | `CORS_ALLOWED_ORIGINS` | http://localhost:3000,http://localhost:5173 | Allowed CORS origins |
+| `SECURITY_HEADERS_ENABLED` | false | Master toggle for production security headers baseline |
+| `SECURITY_HSTS_ENABLED` | false | Enable Strict-Transport-Security response header |
+| `SECURITY_CSP` | (empty) | Value for Content-Security-Policy header |
+| `SECURITY_REFERRER_POLICY` | (empty) | Value for Referrer-Policy header |
+| `SECURITY_PERMISSIONS_POLICY` | (empty) | Value for Permissions-Policy header |
 
 ## API Routes
 

--- a/src/main/java/org/mangala/gateway/security/SecurityHeadersAutoConfiguration.java
+++ b/src/main/java/org/mangala/gateway/security/SecurityHeadersAutoConfiguration.java
@@ -1,0 +1,17 @@
+package org.mangala.gateway.security;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SecurityHeadersProperties.class)
+@ConditionalOnProperty(prefix = "gateway.security.headers", name = "enabled", havingValue = "true")
+public class SecurityHeadersAutoConfiguration {
+
+    @Bean
+    public SecurityHeadersFilter securityHeadersFilter(SecurityHeadersProperties properties) {
+        return new SecurityHeadersFilter(properties);
+    }
+}

--- a/src/main/java/org/mangala/gateway/security/SecurityHeadersFilter.java
+++ b/src/main/java/org/mangala/gateway/security/SecurityHeadersFilter.java
@@ -1,0 +1,63 @@
+package org.mangala.gateway.security;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+public class SecurityHeadersFilter implements GlobalFilter, Ordered {
+
+    private static final String STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+    private static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+    private static final String REFERRER_POLICY = "Referrer-Policy";
+    private static final String PERMISSIONS_POLICY = "Permissions-Policy";
+
+    private static final String HSTS_VALUE = "max-age=31536000; includeSubDomains";
+
+    private final SecurityHeadersProperties properties;
+
+    public SecurityHeadersFilter(SecurityHeadersProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        exchange.getResponse().beforeCommit(() -> {
+            HttpHeaders headers = exchange.getResponse().getHeaders();
+
+            if (properties.isHstsEnabled()) {
+                setIfMissing(headers, STRICT_TRANSPORT_SECURITY, HSTS_VALUE);
+            }
+
+            if (StringUtils.hasText(properties.getCsp())) {
+                setIfMissing(headers, CONTENT_SECURITY_POLICY, properties.getCsp());
+            }
+
+            if (StringUtils.hasText(properties.getReferrerPolicy())) {
+                setIfMissing(headers, REFERRER_POLICY, properties.getReferrerPolicy());
+            }
+
+            if (StringUtils.hasText(properties.getPermissionsPolicy())) {
+                setIfMissing(headers, PERMISSIONS_POLICY, properties.getPermissionsPolicy());
+            }
+
+            return Mono.empty();
+        });
+
+        return chain.filter(exchange);
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 10;
+    }
+
+    private void setIfMissing(HttpHeaders headers, String name, String value) {
+        if (!headers.containsKey(name)) {
+            headers.set(name, value);
+        }
+    }
+}

--- a/src/main/java/org/mangala/gateway/security/SecurityHeadersProperties.java
+++ b/src/main/java/org/mangala/gateway/security/SecurityHeadersProperties.java
@@ -1,0 +1,36 @@
+package org.mangala.gateway.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "gateway.security.headers")
+public class SecurityHeadersProperties {
+
+    /**
+     * Master switch for security headers baseline.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Add Strict-Transport-Security when true.
+     */
+    private boolean hstsEnabled = false;
+
+    /**
+     * Value for Content-Security-Policy header.
+     */
+    private String csp = "";
+
+    /**
+     * Value for Referrer-Policy header.
+     */
+    private String referrerPolicy = "";
+
+    /**
+     * Value for Permissions-Policy header.
+     */
+    private String permissionsPolicy = "";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,6 +102,13 @@ spring:
 
 # Gateway Custom Configuration
 gateway:
+  security:
+    headers:
+      enabled: ${SECURITY_HEADERS_ENABLED:false}
+      hsts-enabled: ${SECURITY_HSTS_ENABLED:false}
+      csp: ${SECURITY_CSP:}
+      referrer-policy: ${SECURITY_REFERRER_POLICY:}
+      permissions-policy: ${SECURITY_PERMISSIONS_POLICY:}
   jwt:
     secret: ${JWT_SECRET:your-256-bit-secret-key-for-jwt-signing-replace-in-production}
     issuer: ${JWT_ISSUER:mangala}

--- a/src/test/java/org/mangala/gateway/security/SecurityHeadersAutoConfigurationTest.java
+++ b/src/test/java/org/mangala/gateway/security/SecurityHeadersAutoConfigurationTest.java
@@ -1,0 +1,25 @@
+package org.mangala.gateway.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityHeadersAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(SecurityHeadersAutoConfiguration.class));
+
+    @Test
+    void shouldNotCreateFilterWhenDisabledByDefault() {
+        contextRunner.run(context -> assertThat(context).doesNotHaveBean(SecurityHeadersFilter.class));
+    }
+
+    @Test
+    void shouldCreateFilterWhenEnabled() {
+        contextRunner
+                .withPropertyValues("gateway.security.headers.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(SecurityHeadersFilter.class));
+    }
+}

--- a/src/test/java/org/mangala/gateway/security/SecurityHeadersFilterTest.java
+++ b/src/test/java/org/mangala/gateway/security/SecurityHeadersFilterTest.java
@@ -1,0 +1,42 @@
+package org.mangala.gateway.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityHeadersFilterTest {
+
+    @Test
+    void shouldAddConfiguredHeadersBeforeCommit() {
+        SecurityHeadersProperties properties = new SecurityHeadersProperties();
+        properties.setHstsEnabled(true);
+        properties.setCsp("default-src 'none'");
+        properties.setReferrerPolicy("strict-origin-when-cross-origin");
+        properties.setPermissionsPolicy("camera=(), microphone=()");
+
+        SecurityHeadersFilter filter = new SecurityHeadersFilter(properties);
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/v1/wallets").build());
+
+        GatewayFilterChain chain = this::completeResponse;
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getHeaders().getFirst("Strict-Transport-Security"))
+                .isEqualTo("max-age=31536000; includeSubDomains");
+        assertThat(exchange.getResponse().getHeaders().getFirst("Content-Security-Policy"))
+                .isEqualTo("default-src 'none'");
+        assertThat(exchange.getResponse().getHeaders().getFirst("Referrer-Policy"))
+                .isEqualTo("strict-origin-when-cross-origin");
+        assertThat(exchange.getResponse().getHeaders().getFirst("Permissions-Policy"))
+                .isEqualTo("camera=(), microphone=()");
+    }
+
+    private Mono<Void> completeResponse(ServerWebExchange exchange) {
+        return exchange.getResponse().setComplete();
+    }
+}


### PR DESCRIPTION
## Summary
- add env-driven security headers baseline at gateway edge
- implement global filter to inject headers right before response commit
- keep defaults disabled for safe rollout
- document new env vars and add tests

## Changes
- add `SecurityHeadersAutoConfiguration` with `@Configuration` + `@ConditionalOnProperty`
- add `SecurityHeadersProperties` (`gateway.security.headers.*`)
- add `SecurityHeadersFilter` for:
  - `Strict-Transport-Security` (when enabled)
  - `Content-Security-Policy`
  - `Referrer-Policy`
  - `Permissions-Policy`
- update `application.yml` with env mappings:
  - `SECURITY_HEADERS_ENABLED`
  - `SECURITY_HSTS_ENABLED`
  - `SECURITY_CSP`
  - `SECURITY_REFERRER_POLICY`
  - `SECURITY_PERMISSIONS_POLICY`
- update README env table
- add tests:
  - `SecurityHeadersAutoConfigurationTest`
  - `SecurityHeadersFilterTest`

## Verification
- `mvn -q -Dtest=SecurityHeadersAutoConfigurationTest,SecurityHeadersFilterTest test`
- `./scripts/check-context-sync.sh`

Closes #4