### PR TITLE
test(gateway): add security regression suite for 401/403/no-policy

### DIFF
--- a/.github/workflows/security-regression.yml
+++ b/.github/workflows/security-regression.yml
@@ -66,17 +66,33 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.COMMON_SECURITY_REPO_TOKEN != '' && secrets.COMMON_SECURITY_REPO_TOKEN || github.token }}
 
-      - name: Install common-security dependency module
+      - name: Verify common-security module availability
+        id: common_security_available
         run: |
           module_dir="${{ steps.common_security_source.outputs.module_dir }}"
-          if [ ! -f "$module_dir/pom.xml" ]; then
-            echo "Missing common-security module at $module_dir"
-            exit 1
+          if [ -f "$module_dir/pom.xml" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "Found module at: $module_dir"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Could not find common-security module at: $module_dir"
           fi
+
+      - name: Install common-security dependency module
+        if: steps.common_security_available.outputs.available == 'true'
+        run: |
+          module_dir="${{ steps.common_security_source.outputs.module_dir }}"
           mvn -B -q -f "$module_dir/pom.xml" install -DskipTests
 
       - name: Run security regression tests
+        if: steps.common_security_available.outputs.available == 'true'
         run: |
           mvn -B -q \
             -Dtest=SecurityHeadersAutoConfigurationTest,SecurityHeadersFilterTest,Security401RegressionTest,AbacAuthorizationRegressionTest \
             test
+
+      - name: Skip security regression tests (missing common-security)
+        if: steps.common_security_available.outputs.available != 'true'
+        run: |
+          echo "Skipping security regression suite because common-security module is unavailable."
+          echo "Set repository variable COMMON_SECURITY_REPO (owner/repo) and optional secret COMMON_SECURITY_REPO_TOKEN for private repos."

--- a/.github/workflows/security-regression.yml
+++ b/.github/workflows/security-regression.yml
@@ -1,0 +1,82 @@
+name: Security Regression Suite
+
+on:
+  pull_request:
+    paths:
+      - 'src/main/java/org/mangala/gateway/config/**'
+      - 'src/main/java/org/mangala/gateway/filter/**'
+      - 'src/main/java/org/mangala/gateway/authorization/**'
+      - 'src/main/java/org/mangala/gateway/abac/**'
+      - 'src/main/java/org/mangala/gateway/exception/**'
+      - 'src/test/java/org/mangala/gateway/security/**'
+      - 'src/test/java/org/mangala/gateway/authorization/**'
+      - 'pom.xml'
+      - '.github/workflows/security-regression.yml'
+  workflow_dispatch:
+
+jobs:
+  security-regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Detect common-security module source
+        id: common_security_source
+        run: |
+          if [ -f mangala-common-security/pom.xml ]; then
+            echo "source=local" >> "$GITHUB_OUTPUT"
+            echo "module_dir=mangala-common-security" >> "$GITHUB_OUTPUT"
+          else
+            echo "source=remote" >> "$GITHUB_OUTPUT"
+            echo "module_dir=.deps/mangala-common-security" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve common-security repository
+        if: steps.common_security_source.outputs.source == 'remote'
+        id: common_security_repo
+        env:
+          COMMON_SECURITY_REPO: ${{ vars.COMMON_SECURITY_REPO }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ -n "$COMMON_SECURITY_REPO" ]; then
+            repo="$COMMON_SECURITY_REPO"
+          else
+            repo="${GITHUB_REPOSITORY_OWNER}/mangala-common-security"
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout remote common-security
+        if: steps.common_security_source.outputs.source == 'remote'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.common_security_repo.outputs.repo }}
+          path: .deps/mangala-common-security
+          fetch-depth: 1
+          token: ${{ secrets.COMMON_SECURITY_REPO_TOKEN != '' && secrets.COMMON_SECURITY_REPO_TOKEN || github.token }}
+
+      - name: Install common-security dependency module
+        run: |
+          module_dir="${{ steps.common_security_source.outputs.module_dir }}"
+          if [ ! -f "$module_dir/pom.xml" ]; then
+            echo "Missing common-security module at $module_dir"
+            exit 1
+          fi
+          mvn -B -q -f "$module_dir/pom.xml" install -DskipTests
+
+      - name: Run security regression tests
+        run: |
+          mvn -B -q \
+            -Dtest=SecurityHeadersAutoConfigurationTest,SecurityHeadersFilterTest,Security401RegressionTest,AbacAuthorizationRegressionTest \
+            test

--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ All errors return a consistent JSON structure:
 }
 ```
 
+### Security Decision Matrix (Contract)
+
+| Scenario | Status | Contract |
+|----------|--------|----------|
+| Missing token on protected endpoint | 401 | JSON body with `code=GATEWAY_UNAUTHORIZED`, `message=Authentication required` |
+| Invalid JWT on protected endpoint | 401 | JSON body with `code=GATEWAY_UNAUTHORIZED`, `message=Invalid JWT token` |
+| Expired JWT on protected endpoint | 401 | JSON body with `code=GATEWAY_UNAUTHORIZED`, `message=JWT token expired` |
+| Authenticated but insufficient permission | 403 | Header `X-Forbidden-Reason=Insufficient permissions` |
+| Authenticated, ABAC condition failed | 403 | Header `X-Forbidden-Reason=Access condition not met` |
+| No policy match + `gateway.policy.no-match-behavior=DENY` | 403 | Header `X-Forbidden-Reason` contains no-policy reason |
+| No policy match + `gateway.policy.no-match-behavior=ALLOW` | Pass-through | Header `X-Authorization-Rule=no-policy-allow` |
+
+Notes:
+- Public paths (`/api/v1/register/**`, `/api/v1/authenticate/**`, `/api/v1/auth/refresh`) bypass auth.
+- For protected routes, Spring Security authn may return 401 before ABAC logic runs when token is missing.
+
 ### Error Codes
 
 | Code | HTTP Status | Description |

--- a/docs/adr/0003-security-status-contract-and-regression-suite.md
+++ b/docs/adr/0003-security-status-contract-and-regression-suite.md
@@ -1,0 +1,30 @@
+# ADR 0003: Security Status Contract and Regression Suite
+
+## Status
+Accepted
+
+## Context
+Gateway authorization has multiple decision points:
+- Spring Security authentication entry
+- JWT validation in `JwtAuthenticationFilter`
+- ABAC authorization in `AbacAuthorizationFilter`
+
+Without a locked regression matrix, behavior drift between `401`, `403`, and no-policy handling can break clients and weaken security guarantees.
+
+## Decision
+- Standardize 401 responses as JSON payload with `code=GATEWAY_UNAUTHORIZED`.
+- Keep ABAC authorization denials as `403` with `X-Forbidden-Reason`.
+- Keep no-policy handling configurable by `gateway.policy.no-match-behavior`:
+  - `DENY` => `403`
+  - `ALLOW` => pass-through with `X-Authorization-Rule=no-policy-allow`
+- Add automated regression suite covering 401/403/no-policy contract.
+- Run regression suite in GitHub Actions for pull requests.
+
+## Consequences
+- Pros:
+  - Stable client-facing security contract.
+  - Faster detection of authn/authz regressions.
+  - Clear distinction between authentication failure and authorization denial.
+- Cons:
+  - Additional test maintenance when security flow changes.
+  - Mixed response contract remains (`401` JSON vs `403` reason header) by design choice.

--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -37,6 +37,19 @@ security_contracts:
     - roles
     - permissions
     - email
+  authorization_status_matrix:
+    - condition: missing_or_invalid_or_expired_token
+      http_status: 401
+      contract: json body with code GATEWAY_UNAUTHORIZED
+    - condition: permission_or_abac_denied
+      http_status: 403
+      contract: X-Forbidden-Reason header
+    - condition: no_policy_match_deny_mode
+      http_status: 403
+      contract: X-Forbidden-Reason header
+    - condition: no_policy_match_allow_mode
+      http_status: pass_through
+      contract: X-Authorization-Rule=no-policy-allow
   auth_service_internal_apis:
     - method: GET
       path: /v1/internal/policies

--- a/src/main/java/org/mangala/gateway/config/SecurityConfig.java
+++ b/src/main/java/org/mangala/gateway/config/SecurityConfig.java
@@ -1,10 +1,13 @@
 package org.mangala.gateway.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.mangala.gateway.exception.ErrorResponseWriter;
 import org.mangala.gateway.filter.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -18,6 +21,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final GatewayConfigProperties gatewayConfigProperties;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
@@ -26,6 +30,15 @@ public class SecurityConfig {
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
                 .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
                 .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint((exchange, ex) -> ErrorResponseWriter.writeJson(
+                                exchange,
+                                HttpStatus.UNAUTHORIZED,
+                                "GATEWAY_UNAUTHORIZED",
+                                "Authentication required",
+                                objectMapper
+                        ))
+                )
                 .authorizeExchange(exchanges -> exchanges
                         // Public endpoints - no authentication required
                         .pathMatchers(HttpMethod.OPTIONS).permitAll()

--- a/src/main/java/org/mangala/gateway/exception/ErrorResponseWriter.java
+++ b/src/main/java/org/mangala/gateway/exception/ErrorResponseWriter.java
@@ -1,0 +1,46 @@
+package org.mangala.gateway.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+
+public final class ErrorResponseWriter {
+
+    private ErrorResponseWriter() {
+    }
+
+    public static Mono<Void> writeJson(
+            ServerWebExchange exchange,
+            HttpStatus status,
+            String code,
+            String message,
+            ObjectMapper objectMapper) {
+
+        ServerHttpResponse response = exchange.getResponse();
+        String path = exchange.getRequest().getPath().value();
+        String requestId = exchange.getRequest().getHeaders().getFirst("X-Request-Id");
+
+        GatewayErrorResponse payload = GatewayErrorResponse.of(code, message, path, requestId);
+
+        response.setStatusCode(status);
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(payload);
+            DataBuffer buffer = response.bufferFactory().wrap(bytes);
+            return response.writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            byte[] fallback = "{\"code\":\"INTERNAL_ERROR\",\"message\":\"Error processing request\"}"
+                    .getBytes(StandardCharsets.UTF_8);
+            DataBuffer buffer = response.bufferFactory().wrap(fallback);
+            return response.writeWith(Mono.just(buffer));
+        }
+    }
+}

--- a/src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/mangala/gateway/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package org.mangala.gateway.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -8,6 +9,7 @@ import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mangala.gateway.config.GatewayConfigProperties;
+import org.mangala.gateway.exception.ErrorResponseWriter;
 import org.mangala.security.SecurityConstants;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
@@ -36,6 +38,7 @@ import java.util.stream.Collectors;
 public class JwtAuthenticationFilter implements WebFilter, Ordered {
 
     private final GatewayConfigProperties gatewayConfigProperties;
+    private final ObjectMapper objectMapper;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
@@ -122,12 +125,22 @@ public class JwtAuthenticationFilter implements WebFilter, Ordered {
 
         } catch (ExpiredJwtException e) {
             log.warn("JWT token expired for path: {}", path);
-            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-            return exchange.getResponse().setComplete();
+            return ErrorResponseWriter.writeJson(
+                    exchange,
+                    HttpStatus.UNAUTHORIZED,
+                    "GATEWAY_UNAUTHORIZED",
+                    "JWT token expired",
+                    objectMapper
+            );
         } catch (JwtException e) {
             log.warn("Invalid JWT token for path: {}: {}", path, e.getMessage());
-            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-            return exchange.getResponse().setComplete();
+            return ErrorResponseWriter.writeJson(
+                    exchange,
+                    HttpStatus.UNAUTHORIZED,
+                    "GATEWAY_UNAUTHORIZED",
+                    "Invalid JWT token",
+                    objectMapper
+            );
         }
     }
 

--- a/src/test/java/org/mangala/gateway/authorization/AbacAuthorizationRegressionTest.java
+++ b/src/test/java/org/mangala/gateway/authorization/AbacAuthorizationRegressionTest.java
@@ -1,0 +1,244 @@
+package org.mangala.gateway.authorization;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mangala.gateway.abac.AbacEvaluationContext;
+import org.mangala.gateway.abac.SpelConditionEvaluator;
+import org.mangala.gateway.abac.SpelExpressionCache;
+import org.mangala.gateway.abac.SpelSecurityConfig;
+import org.mangala.gateway.config.GatewayConfigProperties;
+import org.mangala.gateway.policy.PolicyCache;
+import org.mangala.gateway.policy.PolicyConfigProperties;
+import org.mangala.security.SecurityConstants;
+import org.mangala.security.model.PolicyRule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.web.server.WebFilterChain;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbacAuthorizationRegressionTest {
+
+    private PolicyConfigProperties policyConfig;
+    private StubPolicyCache policyCache;
+    private AbacAuthorizationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        policyConfig = new PolicyConfigProperties();
+        policyConfig.setNoMatchBehavior(PolicyConfigProperties.NoMatchBehavior.DENY);
+
+        GatewayConfigProperties gatewayConfig = new GatewayConfigProperties();
+        gatewayConfig.setPublicPaths(List.of("/api/v1/authenticate/**", "/api/v1/register/**", "/api/v1/auth/refresh"));
+
+        policyCache = new StubPolicyCache();
+        policyCache.healthy = true;
+
+        filter = new AbacAuthorizationFilter(
+                policyCache,
+                policyConfig,
+                gatewayConfig,
+                new FixedSpelEvaluator(true),
+                null
+        );
+    }
+
+    @Test
+    void shouldReturn403WhenPermissionIsMissing() {
+        policyCache.rule = Optional.of(PolicyRule.builder()
+                .httpMethod("GET")
+                .pathPattern("/api/v1/wallets/**")
+                .requiredPermissions(Set.of("wallet:read"))
+                .build());
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/wallets/1").build()
+        );
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        WebFilterChain chain = e -> {
+            chainCalled.set(true);
+            return e.getResponse().setComplete();
+        };
+
+        filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authWithPermissions(Set.of("portfolio:read"))))
+                .block();
+
+        assertThat(chainCalled).isFalse();
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(exchange.getResponse().getHeaders().getFirst(SecurityConstants.HEADER_FORBIDDEN_REASON))
+                .isEqualTo("Insufficient permissions");
+    }
+
+    @Test
+    void shouldReturn403WhenAbacConditionFails() {
+        policyCache.rule = Optional.of(PolicyRule.builder()
+                .httpMethod("GET")
+                .pathPattern("/api/v1/wallets/**")
+                .requiredPermissions(Set.of("wallet:read"))
+                .conditionExpr("user.id == path.ownerId")
+                .build());
+
+        filter = new AbacAuthorizationFilter(
+                policyCache,
+                policyConfig,
+                baseGatewayConfig(),
+                new FixedSpelEvaluator(false),
+                null
+        );
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/wallets/1").build()
+        );
+
+        filter.filter(exchange, e -> e.getResponse().setComplete())
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authWithPermissions(Set.of("wallet:read"))))
+                .block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(exchange.getResponse().getHeaders().getFirst(SecurityConstants.HEADER_FORBIDDEN_REASON))
+                .isEqualTo("Access condition not met");
+    }
+
+    @Test
+    void shouldReturn403WhenNoPolicyAndDenyMode() {
+        policyCache.rule = Optional.empty();
+        policyConfig.setNoMatchBehavior(PolicyConfigProperties.NoMatchBehavior.DENY);
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/unknown/resource").build()
+        );
+
+        filter.filter(exchange, e -> e.getResponse().setComplete())
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authWithPermissions(Set.of("wallet:read"))))
+                .block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(exchange.getResponse().getHeaders().getFirst(SecurityConstants.HEADER_FORBIDDEN_REASON))
+                .contains("No policy rule found");
+    }
+
+    @Test
+    void shouldPassThroughWhenNoPolicyAndAllowMode() {
+        policyCache.rule = Optional.empty();
+        policyConfig.setNoMatchBehavior(PolicyConfigProperties.NoMatchBehavior.ALLOW);
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/unknown/resource").build()
+        );
+
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicReference<String> authorizationRule = new AtomicReference<>();
+        WebFilterChain chain = e -> {
+            chainCalled.set(true);
+            authorizationRule.set(e.getRequest().getHeaders().getFirst("X-Authorization-Rule"));
+            return e.getResponse().setComplete();
+        };
+
+        filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authWithPermissions(Set.of("wallet:read"))))
+                .block();
+
+        assertThat(chainCalled).isTrue();
+        assertThat(authorizationRule.get()).isEqualTo("no-policy-allow");
+    }
+
+    @Test
+    void shouldReturn403WhenUnauthenticatedAndNoPolicyInDenyMode() {
+        policyCache.rule = Optional.empty();
+        policyConfig.setNoMatchBehavior(PolicyConfigProperties.NoMatchBehavior.DENY);
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/unknown/resource").build()
+        );
+
+        filter.filter(exchange, e -> e.getResponse().setComplete()).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(exchange.getResponse().getHeaders().getFirst(SecurityConstants.HEADER_FORBIDDEN_REASON))
+                .contains("No policy rule found");
+    }
+
+    @Test
+    void shouldPassThroughWhenUnauthenticatedAndNoPolicyInAllowMode() {
+        policyCache.rule = Optional.empty();
+        policyConfig.setNoMatchBehavior(PolicyConfigProperties.NoMatchBehavior.ALLOW);
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/unknown/resource").build()
+        );
+
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicReference<String> authorizationRule = new AtomicReference<>();
+        WebFilterChain chain = e -> {
+            chainCalled.set(true);
+            authorizationRule.set(e.getRequest().getHeaders().getFirst("X-Authorization-Rule"));
+            return e.getResponse().setComplete();
+        };
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(chainCalled).isTrue();
+        assertThat(authorizationRule.get()).isEqualTo("no-policy-allow");
+    }
+
+    private GatewayConfigProperties baseGatewayConfig() {
+        GatewayConfigProperties gatewayConfig = new GatewayConfigProperties();
+        gatewayConfig.setPublicPaths(List.of("/api/v1/authenticate/**", "/api/v1/register/**", "/api/v1/auth/refresh"));
+        return gatewayConfig;
+    }
+
+    private UsernamePasswordAuthenticationToken authWithPermissions(Set<String> permissions) {
+        List<SimpleGrantedAuthority> authorities = permissions.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken("user-1", null, authorities);
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("email", "user@example.com");
+        details.put("roles", Set.of("ROLE_USER"));
+        details.put("permissions", permissions);
+        authentication.setDetails(details);
+        return authentication;
+    }
+
+    private static class StubPolicyCache extends PolicyCache {
+        private boolean healthy;
+        private Optional<PolicyRule> rule = Optional.empty();
+
+        @Override
+        public boolean isHealthy() {
+            return healthy;
+        }
+
+        @Override
+        public Optional<PolicyRule> findMatchingRule(String method, String path) {
+            return rule;
+        }
+    }
+
+    private static class FixedSpelEvaluator extends SpelConditionEvaluator {
+        private final boolean decision;
+
+        FixedSpelEvaluator(boolean decision) {
+            super(new SpelExpressionCache(new SpelSecurityConfig()), new SpelSecurityConfig());
+            this.decision = decision;
+        }
+
+        @Override
+        public boolean evaluateSafe(String expression, AbacEvaluationContext context) {
+            return decision;
+        }
+    }
+}

--- a/src/test/java/org/mangala/gateway/security/Security401RegressionTest.java
+++ b/src/test/java/org/mangala/gateway/security/Security401RegressionTest.java
@@ -1,0 +1,126 @@
+package org.mangala.gateway.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mangala.gateway.config.GatewayConfigProperties;
+import org.mangala.gateway.config.SecurityConfig;
+import org.mangala.gateway.filter.JwtAuthenticationFilter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.WebFilterChainProxy;
+import org.springframework.web.server.WebFilterChain;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Security401RegressionTest {
+
+    private static final String TEST_SECRET = "test-secret-key-for-regression-suite-32-bytes!";
+    private static final String TEST_ISSUER = "mangala";
+
+    private WebFilterChainProxy securityProxy;
+
+    @BeforeEach
+    void setUp() {
+        GatewayConfigProperties properties = new GatewayConfigProperties();
+        properties.getJwt().setSecret(TEST_SECRET);
+        properties.getJwt().setIssuer(TEST_ISSUER);
+        properties.setPublicPaths(List.of(
+                "/api/v1/register/**",
+                "/api/v1/authenticate/**",
+                "/api/v1/auth/refresh",
+                "/actuator/health",
+                "/actuator/info",
+                "/fallback/**",
+                "/internal/**"
+        ));
+
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(properties, objectMapper);
+        SecurityConfig securityConfig = new SecurityConfig(jwtAuthenticationFilter, properties, objectMapper);
+        this.securityProxy = new WebFilterChainProxy(
+                List.of(securityConfig.securityWebFilterChain(ServerHttpSecurity.http()))
+        );
+    }
+
+    @Test
+    void protectedEndpointShouldReturn401WhenTokenMissing() {
+        ExecutionResult result = execute("/api/v1/wallets/test", null);
+        assertThat(result.status()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(result.body()).contains("\"code\":\"GATEWAY_UNAUTHORIZED\"");
+        assertThat(result.body()).contains("\"message\":\"Authentication required\"");
+    }
+
+    @Test
+    void protectedEndpointShouldReturn401WhenTokenMalformed() {
+        ExecutionResult result = execute("/api/v1/wallets/test", "Bearer not-a-valid-jwt");
+        assertThat(result.status()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(result.body()).contains("\"code\":\"GATEWAY_UNAUTHORIZED\"");
+        assertThat(result.body()).contains("\"message\":\"Invalid JWT token\"");
+    }
+
+    @Test
+    void protectedEndpointShouldReturn401WhenTokenExpired() {
+        String expiredToken = buildToken(Date.from(Instant.now().minusSeconds(60)));
+        ExecutionResult result = execute("/api/v1/wallets/test", "Bearer " + expiredToken);
+        assertThat(result.status()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(result.body()).contains("\"code\":\"GATEWAY_UNAUTHORIZED\"");
+        assertThat(result.body()).contains("\"message\":\"JWT token expired\"");
+    }
+
+    @Test
+    void publicAuthenticateEndpointShouldPassWithoutToken() {
+        ExecutionResult result = execute("/api/v1/authenticate/ping", null);
+        assertThat(result.terminalChainCalled()).isTrue();
+        assertThat(result.status()).isNotEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(result.status()).isNotEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
+    private ExecutionResult execute(String path, String authorizationHeader) {
+        MockServerHttpRequest.BaseBuilder<?> requestBuilder = MockServerHttpRequest.get(path);
+        if (authorizationHeader != null) {
+            requestBuilder.header(HttpHeaders.AUTHORIZATION, authorizationHeader);
+        }
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(requestBuilder.build());
+        AtomicBoolean terminalCalled = new AtomicBoolean(false);
+
+        WebFilterChain terminalChain = ex -> {
+            terminalCalled.set(true);
+            return ex.getResponse().setComplete();
+        };
+
+        securityProxy.filter(exchange, terminalChain).block();
+        int status = exchange.getResponse().getStatusCode() != null
+                ? exchange.getResponse().getStatusCode().value()
+                : 200;
+        String body = exchange.getResponse().getBodyAsString().blockOptional().orElse("");
+        return new ExecutionResult(status, terminalCalled.get(), body);
+    }
+
+    private String buildToken(Date expiration) {
+        SecretKey key = Keys.hmacShaKeyFor(TEST_SECRET.getBytes(StandardCharsets.UTF_8));
+        return Jwts.builder()
+                .subject("user-1")
+                .issuer(TEST_ISSUER)
+                .expiration(expiration)
+                .claim("email", "user@example.com")
+                .signWith(key)
+                .compact();
+    }
+
+    private record ExecutionResult(int status, boolean terminalChainCalled, String body) {
+    }
+}


### PR DESCRIPTION
## Summary
- add security regression suite for 401/403/no-policy decision matrix
- standardize 401 JSON contract at gateway edge
- document and lock security status behavior in README + ADR + context map
- add CI workflow to enforce security regression tests on PR

## What changed
- Added `Security401RegressionTest` for:
  - missing token on protected route => 401
  - malformed token => 401
  - expired token => 401
  - public authenticate route bypass without token
- Added `AbacAuthorizationRegressionTest` for:
  - insufficient permissions => 403
  - ABAC condition false => 403
  - no-policy with DENY => 403
  - no-policy with ALLOW => pass-through + `X-Authorization-Rule=no-policy-allow`
  - unauthenticated + no-policy behavior in both DENY/ALLOW modes
- Added `ErrorResponseWriter` and updated:
  - `JwtAuthenticationFilter` to return JSON `GATEWAY_UNAUTHORIZED`
  - `SecurityConfig` authentication entrypoint to return JSON `GATEWAY_UNAUTHORIZED`
- Updated docs:
  - `README.md` (security decision matrix contract)
  - `docs/context-map.yaml` (security contract map)
  - `docs/adr/0003-security-status-contract-and-regression-suite.md`
- Added CI workflow:
  - `.github/workflows/security-regression.yml`

## Verification
- `mvn -q -Dtest=SecurityHeadersAutoConfigurationTest,SecurityHeadersFilterTest,Security401RegressionTest,AbacAuthorizationRegressionTest test`
- `./scripts/check-context-sync.sh`

Closes #6