### PR TITLE
test(gateway): add contract tests for auth internal policy API

### DIFF
--- a/.github/workflows/policy-contract-tests.yml
+++ b/.github/workflows/policy-contract-tests.yml
@@ -1,0 +1,90 @@
+name: Policy Contract Tests
+
+on:
+  pull_request:
+    paths:
+      - 'src/main/java/org/mangala/gateway/policy/**'
+      - 'src/test/java/org/mangala/gateway/policy/**'
+      - 'docs/context-map.yaml'
+      - 'pom.xml'
+      - '.github/workflows/policy-contract-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  policy-contract-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Detect common-security module source
+        id: common_security_source
+        run: |
+          if [ -f mangala-common-security/pom.xml ]; then
+            echo "source=local" >> "$GITHUB_OUTPUT"
+            echo "module_dir=mangala-common-security" >> "$GITHUB_OUTPUT"
+          else
+            echo "source=remote" >> "$GITHUB_OUTPUT"
+            echo "module_dir=.deps/mangala-common-security" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve common-security repository
+        if: steps.common_security_source.outputs.source == 'remote'
+        id: common_security_repo
+        env:
+          COMMON_SECURITY_REPO: ${{ vars.COMMON_SECURITY_REPO }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ -n "$COMMON_SECURITY_REPO" ]; then
+            repo="$COMMON_SECURITY_REPO"
+          else
+            repo="${GITHUB_REPOSITORY_OWNER}/mangala-common-security"
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout remote common-security
+        if: steps.common_security_source.outputs.source == 'remote'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.common_security_repo.outputs.repo }}
+          path: .deps/mangala-common-security
+          fetch-depth: 1
+          token: ${{ secrets.COMMON_SECURITY_REPO_TOKEN != '' && secrets.COMMON_SECURITY_REPO_TOKEN || github.token }}
+
+      - name: Verify common-security module availability
+        id: common_security_available
+        run: |
+          module_dir="${{ steps.common_security_source.outputs.module_dir }}"
+          if [ -f "$module_dir/pom.xml" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Missing common-security module at: $module_dir"
+          fi
+
+      - name: Install common-security dependency module
+        if: steps.common_security_available.outputs.available == 'true'
+        run: |
+          module_dir="${{ steps.common_security_source.outputs.module_dir }}"
+          mvn -B -q -f "$module_dir/pom.xml" install -DskipTests
+
+      - name: Run policy contract tests
+        if: steps.common_security_available.outputs.available == 'true'
+        run: mvn -B -q -Dtest=AuthPolicyApiClientContractTest test
+
+      - name: Skip contract tests (missing common-security)
+        if: steps.common_security_available.outputs.available != 'true'
+        run: |
+          echo "Skipping policy contract tests because common-security module is unavailable."
+          echo "Set repository variable COMMON_SECURITY_REPO (owner/repo) and optional secret COMMON_SECURITY_REPO_TOKEN for private repos."

--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -22,6 +22,9 @@ architecture:
     - name: policy_engine
       package: org.mangala.gateway.policy
       responsibility: load/cache/reload policy rules
+    - name: policy_contract_client
+      package: org.mangala.gateway.policy
+      responsibility: consume auth internal policy APIs with stable contract expectations
     - name: abac_eval
       package: org.mangala.gateway.abac
       responsibility: secure SpEL condition evaluation
@@ -57,6 +60,14 @@ security_contracts:
     - method: GET
       path: /v1/internal/policies/version
       purpose: version check for conditional reload
+  contract_test_coverage:
+    - producer: mangala-authentication internal policy APIs
+    - consumer: gateway AuthPolicyApiClient + PolicyLoader
+    - checks:
+        - policies payload schema
+        - version payload numeric contract
+        - 4xx/5xx error handling
+        - malformed payload/content-type failures
 
 policy_cache_behavior:
   cache_type: in_memory

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/org/mangala/gateway/policy/AuthPolicyApiClient.java
+++ b/src/main/java/org/mangala/gateway/policy/AuthPolicyApiClient.java
@@ -1,0 +1,43 @@
+package org.mangala.gateway.policy;
+
+import lombok.RequiredArgsConstructor;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AuthPolicyApiClient {
+
+    private final WebClient.Builder webClientBuilder;
+    private final PolicyConfigProperties policyConfig;
+
+    public Mono<List<ApiPermissionDTO>> fetchPolicies() {
+        return createClient()
+                .get()
+                .uri("/v1/internal/policies")
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToFlux(ApiPermissionDTO.class)
+                .collectList();
+    }
+
+    public Mono<Long> fetchPolicyVersion() {
+        return createClient()
+                .get()
+                .uri("/v1/internal/policies/version")
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(Long.class);
+    }
+
+    private WebClient createClient() {
+        return webClientBuilder
+                .baseUrl(policyConfig.getAuthServiceUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyLoader.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyLoader.java
@@ -13,7 +13,6 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
@@ -34,7 +33,7 @@ public class PolicyLoader implements ApplicationRunner {
 
     private final PolicyCache policyCache;
     private final PolicyConfigProperties policyConfig;
-    private final WebClient.Builder webClientBuilder;
+    private final AuthPolicyApiClient authPolicyApiClient;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final CircuitBreaker policyLoaderCircuitBreaker;
     private final TimeLimiter policyLoaderTimeLimiter;
@@ -62,15 +61,7 @@ public class PolicyLoader implements ApplicationRunner {
 
         log.info("Loading policies from Auth Service: {}", policyConfig.getAuthServiceUrl());
 
-        WebClient client = webClientBuilder
-                .baseUrl(policyConfig.getAuthServiceUrl())
-                .build();
-
-        return client.get()
-                .uri("/v1/internal/policies")
-                .retrieve()
-                .bodyToFlux(ApiPermissionDTO.class)
-                .collectList()
+        return authPolicyApiClient.fetchPolicies()
                 // Apply time limiter first, then circuit breaker
                 .transformDeferred(TimeLimiterOperator.of(policyLoaderTimeLimiter))
                 .transformDeferred(CircuitBreakerOperator.of(policyLoaderCircuitBreaker))
@@ -189,14 +180,7 @@ public class PolicyLoader implements ApplicationRunner {
     }
 
     private Mono<Long> fetchVersionFromAuthService() {
-        WebClient client = webClientBuilder
-                .baseUrl(policyConfig.getAuthServiceUrl())
-                .build();
-
-        return client.get()
-                .uri("/v1/internal/policies/version")
-                .retrieve()
-                .bodyToMono(Long.class)
+        return authPolicyApiClient.fetchPolicyVersion()
                 // Apply circuit breaker to version fetch as well
                 .transformDeferred(CircuitBreakerOperator.of(policyLoaderCircuitBreaker))
                 .doOnNext(v -> {

--- a/src/test/java/org/mangala/gateway/policy/AuthPolicyApiClientContractTest.java
+++ b/src/test/java/org/mangala/gateway/policy/AuthPolicyApiClientContractTest.java
@@ -1,0 +1,121 @@
+package org.mangala.gateway.policy;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthPolicyApiClientContractTest {
+
+    private MockWebServer mockWebServer;
+    private AuthPolicyApiClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        PolicyConfigProperties policyConfig = new PolicyConfigProperties();
+        policyConfig.setAuthServiceUrl(mockWebServer.url("/").toString());
+
+        client = new AuthPolicyApiClient(WebClient.builder(), policyConfig);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void shouldParsePoliciesContract() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .setBody("""
+                        [
+                          {
+                            "id": "rule-1",
+                            "httpMethod": "GET",
+                            "pathPattern": "/api/v1/wallets",
+                            "permissionCode": "wallet:read",
+                            "conditionExpr": null,
+                            "serviceName": "wallet-service",
+                            "priority": 10,
+                            "active": true
+                          }
+                        ]
+                        """));
+
+        StepVerifier.create(client.fetchPolicies())
+                .assertNext(policies -> {
+                    assertThat(policies).hasSize(1);
+                    ApiPermissionDTO policy = policies.getFirst();
+                    assertThat(policy.getId()).isEqualTo("rule-1");
+                    assertThat(policy.getHttpMethod()).isEqualTo("GET");
+                    assertThat(policy.getPathPattern()).isEqualTo("/api/v1/wallets");
+                    assertThat(policy.getPermissionCode()).isEqualTo("wallet:read");
+                    assertThat(policy.getPriority()).isEqualTo(10);
+                    assertThat(policy.isActive()).isTrue();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldParsePolicyVersionContractAsJsonNumber() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .setBody("42"));
+
+        StepVerifier.create(client.fetchPolicyVersion())
+                .expectNext(42L)
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldFailOnPolicyEndpointServerError() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .setBody("{\"error\":\"internal\"}"));
+
+        StepVerifier.create(client.fetchPolicies())
+                .expectErrorSatisfies(error -> assertThat(error).isInstanceOf(WebClientResponseException.class))
+                .verify();
+    }
+
+    @Test
+    void shouldFailWhenVersionPayloadIsNotJsonNumber() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .setBody("\"not-a-number\""));
+
+        StepVerifier.create(client.fetchPolicyVersion())
+                .expectError()
+                .verify();
+    }
+
+    @Test
+    void shouldFailWhenPoliciesPayloadWrongContentType() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", MediaType.TEXT_PLAIN_VALUE)
+                .setBody("not-json"));
+
+        StepVerifier.create(client.fetchPolicies())
+                .expectError()
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add contract-focused consumer tests for auth internal policy APIs used by gateway policy loader
- extract policy API calling logic into a dedicated client (`AuthPolicyApiClient`)
- wire policy loader to use the contract-aware client
- add CI workflow to run policy contract tests on PRs

## Changes
- Added `AuthPolicyApiClient`:
  - `fetchPolicies()` for `GET /v1/internal/policies`
  - `fetchPolicyVersion()` for `GET /v1/internal/policies/version`
- Refactored `PolicyLoader` to consume `AuthPolicyApiClient`
- Added `AuthPolicyApiClientContractTest` with scenarios:
  - valid policies payload schema
  - valid numeric version payload
  - server error handling (5xx)
  - malformed version payload
  - wrong content type handling
- Added test dependency `mockwebserver`
- Added workflow `.github/workflows/policy-contract-tests.yml`
- Updated `docs/context-map.yaml` with contract-test coverage context

## Verification
- `mvn -q -Dtest=AuthPolicyApiClientContractTest test`
- `mvn -q -Dtest=SecurityHeadersAutoConfigurationTest,SecurityHeadersFilterTest,Security401RegressionTest,AbacAuthorizationRegressionTest,AuthPolicyApiClientContractTest test`
- `./scripts/check-context-sync.sh`

Closes #8