### PR TITLE
feat(gateway): harden policy API mTLS for non-dev profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ docker run -d \
 | `SECURITY_CSP` | (empty) | Value for Content-Security-Policy header |
 | `SECURITY_REFERRER_POLICY` | (empty) | Value for Referrer-Policy header |
 | `SECURITY_PERMISSIONS_POLICY` | (empty) | Value for Permissions-Policy header |
+| `POLICY_MTLS_ENABLED` | false | Enable mTLS client for gateway -> auth internal policy APIs |
+| `POLICY_MTLS_KEY_STORE_PATH` | (empty) | Client keystore path (required in non-dev when mTLS enabled) |
+| `POLICY_MTLS_KEY_STORE_PASSWORD` | (empty) | Client keystore password |
+| `POLICY_MTLS_KEY_STORE_TYPE` | PKCS12 | Client keystore type |
+| `POLICY_MTLS_TRUST_STORE_PATH` | (empty) | Truststore path for auth service certificate chain |
+| `POLICY_MTLS_TRUST_STORE_PASSWORD` | (empty) | Truststore password |
+| `POLICY_MTLS_TRUST_STORE_TYPE` | PKCS12 | Truststore type |
+| `POLICY_MTLS_ENFORCE_NON_DEV` | true | Fail startup in non-dev profiles if policy mTLS is not fully configured |
+| `POLICY_DEV_PROFILES` | dev,local,test | Profiles considered development-like for mTLS enforcement guard |
 
 ## API Routes
 

--- a/docs/adr/0004-policy-api-mtls-hardening-non-dev.md
+++ b/docs/adr/0004-policy-api-mtls-hardening-non-dev.md
@@ -1,0 +1,23 @@
+# ADR 0004: Enforce Policy API mTLS in Non-Dev Profiles
+
+## Status
+Accepted
+
+## Context
+Gateway loads authorization policy snapshots from auth internal APIs (`/v1/internal/policies*`).
+Without explicit profile-based safeguards, non-dev environments can run with plain HTTP or missing client-certificate configuration.
+
+## Decision
+- Add gateway policy API mTLS client configuration under `gateway.policy.mtls.*`.
+- Use mTLS-capable WebClient builder for `AuthPolicyApiClient` when `gateway.policy.mtls.enabled=true`.
+- Add startup guard:
+  - if active profile is non-dev and `gateway.policy.profile-guard.enforce-mtls-in-non-dev=true`
+  - then require `gateway.policy.mtls.enabled=true` and non-empty key/trust store settings.
+
+## Consequences
+- Pros:
+  - Prevents insecure non-dev deployments by fail-fast startup validation.
+  - Creates explicit transport-security contract for policy loading path.
+- Cons:
+  - Requires certificate material provisioning in non-dev environments.
+  - Misconfiguration causes startup failure until mTLS settings are corrected.

--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -60,6 +60,11 @@ security_contracts:
     - method: GET
       path: /v1/internal/policies/version
       purpose: version check for conditional reload
+  internal_api_transport_security:
+    - mode: mtls
+      applies_to: gateway -> auth internal policy APIs
+      config_prefix: gateway.policy.mtls
+      non_dev_guard: gateway.policy.profile-guard.enforce-mtls-in-non-dev
   contract_test_coverage:
     - producer: mangala-authentication internal policy APIs
     - consumer: gateway AuthPolicyApiClient + PolicyLoader
@@ -68,6 +73,9 @@ security_contracts:
         - version payload numeric contract
         - 4xx/5xx error handling
         - malformed payload/content-type failures
+  non_dev_profiles:
+    - when active profiles are not in gateway.policy.profile-guard.dev-profiles
+    - policy API mTLS must be enabled and keystore/truststore fields must be configured
 
 policy_cache_behavior:
   cache_type: in_memory

--- a/src/main/java/org/mangala/gateway/policy/AuthPolicyApiClient.java
+++ b/src/main/java/org/mangala/gateway/policy/AuthPolicyApiClient.java
@@ -2,6 +2,7 @@ package org.mangala.gateway.policy;
 
 import lombok.RequiredArgsConstructor;
 import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,6 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuthPolicyApiClient {
 
+    @Qualifier("policyApiWebClientBuilder")
     private final WebClient.Builder webClientBuilder;
     private final PolicyConfigProperties policyConfig;
 

--- a/src/main/java/org/mangala/gateway/policy/PolicyApiMtlsWebClientConfig.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyApiMtlsWebClientConfig.java
@@ -1,0 +1,61 @@
+package org.mangala.gateway.policy;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.KeyStore;
+
+@Slf4j
+@Configuration
+public class PolicyApiMtlsWebClientConfig {
+
+    @Bean
+    @Qualifier("policyApiWebClientBuilder")
+    public WebClient.Builder policyApiWebClientBuilder(PolicyConfigProperties policyConfig) {
+        if (!policyConfig.getMtls().isEnabled()) {
+            return WebClient.builder();
+        }
+
+        try {
+            SslContext sslContext = buildSslContext(policyConfig.getMtls());
+            HttpClient httpClient = HttpClient.create().secure(ssl -> ssl.sslContext(sslContext));
+            return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize mTLS WebClient for policy API", e);
+        }
+    }
+
+    private SslContext buildSslContext(PolicyConfigProperties.MtlsConfig mtls) throws Exception {
+        KeyStore keyStore = loadStore(mtls.getKeyStoreType(), mtls.getKeyStorePath(), mtls.getKeyStorePassword());
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, mtls.getKeyStorePassword().toCharArray());
+
+        KeyStore trustStore = loadStore(mtls.getTrustStoreType(), mtls.getTrustStorePath(), mtls.getTrustStorePassword());
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+
+        return SslContextBuilder.forClient()
+                .keyManager(kmf)
+                .trustManager(tmf)
+                .build();
+    }
+
+    private KeyStore loadStore(String type, String path, String password) throws Exception {
+        KeyStore store = KeyStore.getInstance(type);
+        try (InputStream input = new FileInputStream(path)) {
+            store.load(input, password.toCharArray());
+        }
+        return store;
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyApiSecurityProfileGuard.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyApiSecurityProfileGuard.java
@@ -1,0 +1,73 @@
+package org.mangala.gateway.policy;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class PolicyApiSecurityProfileGuard implements ApplicationRunner {
+
+    private final PolicyConfigProperties policyConfig;
+    private final Environment environment;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!isNonDevProfileActive()) {
+            return;
+        }
+
+        if (!policyConfig.getProfileGuard().isEnforceMtlsInNonDev()) {
+            log.warn("Policy API non-dev mTLS enforcement is disabled by configuration");
+            return;
+        }
+
+        if (!policyConfig.getMtls().isEnabled()) {
+            throw new IllegalStateException(
+                    "Policy API mTLS must be enabled in non-dev profiles (gateway.policy.mtls.enabled=true)");
+        }
+
+        validateMtlsMaterial(policyConfig.getMtls());
+    }
+
+    private boolean isNonDevProfileActive() {
+        Set<String> activeProfiles = Arrays.stream(environment.getActiveProfiles())
+                .collect(Collectors.toSet());
+        if (activeProfiles.isEmpty()) {
+            return false;
+        }
+
+        Set<String> devProfiles = policyConfig.getProfileGuard().getDevProfiles().stream()
+                .map(String::trim)
+                .collect(Collectors.toSet());
+
+        return activeProfiles.stream().anyMatch(profile -> !devProfiles.contains(profile));
+    }
+
+    private void validateMtlsMaterial(PolicyConfigProperties.MtlsConfig mtls) {
+        if (!StringUtils.hasText(mtls.getKeyStorePath())) {
+            throw new IllegalStateException("gateway.policy.mtls.key-store-path is required in non-dev profiles");
+        }
+        if (!StringUtils.hasText(mtls.getKeyStorePassword())) {
+            throw new IllegalStateException("gateway.policy.mtls.key-store-password is required in non-dev profiles");
+        }
+        if (!StringUtils.hasText(mtls.getTrustStorePath())) {
+            throw new IllegalStateException("gateway.policy.mtls.trust-store-path is required in non-dev profiles");
+        }
+        if (!StringUtils.hasText(mtls.getTrustStorePassword())) {
+            throw new IllegalStateException("gateway.policy.mtls.trust-store-password is required in non-dev profiles");
+        }
+    }
+}

--- a/src/main/java/org/mangala/gateway/policy/PolicyConfigProperties.java
+++ b/src/main/java/org/mangala/gateway/policy/PolicyConfigProperties.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
  * Configuration properties for policy cache and loading.
  */
@@ -61,8 +63,71 @@ public class PolicyConfigProperties {
      */
     private NoMatchBehavior noMatchBehavior = NoMatchBehavior.DENY;
 
+    /**
+     * Policy API mTLS client configuration for gateway -> auth-service.
+     */
+    private MtlsConfig mtls = new MtlsConfig();
+
+    /**
+     * Enforce mTLS settings when running in non-dev profiles.
+     */
+    private ProfileGuardConfig profileGuard = new ProfileGuardConfig();
+
     public enum NoMatchBehavior {
         DENY,
         ALLOW
+    }
+
+    @Getter
+    @Setter
+    public static class MtlsConfig {
+        /**
+         * Enable mTLS client certificate for policy API calls.
+         */
+        private boolean enabled = false;
+
+        /**
+         * Path to client key store (PKCS12/JKS).
+         */
+        private String keyStorePath;
+
+        /**
+         * Key store password.
+         */
+        private String keyStorePassword;
+
+        /**
+         * Key store type.
+         */
+        private String keyStoreType = "PKCS12";
+
+        /**
+         * Path to trust store with auth-service CA/server cert.
+         */
+        private String trustStorePath;
+
+        /**
+         * Trust store password.
+         */
+        private String trustStorePassword;
+
+        /**
+         * Trust store type.
+         */
+        private String trustStoreType = "PKCS12";
+    }
+
+    @Getter
+    @Setter
+    public static class ProfileGuardConfig {
+        /**
+         * Enforce mTLS on non-dev profiles.
+         */
+        private boolean enforceMtlsInNonDev = true;
+
+        /**
+         * Profiles considered development-like and excluded from strict enforcement.
+         */
+        private List<String> devProfiles = List.of("dev", "local", "test");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,6 +137,17 @@ gateway:
     use-kafka: ${POLICY_USE_KAFKA:false}
     include-in-health-check: ${POLICY_HEALTH_CHECK:true}
     no-match-behavior: ${POLICY_NO_MATCH_BEHAVIOR:DENY}
+    mtls:
+      enabled: ${POLICY_MTLS_ENABLED:false}
+      key-store-path: ${POLICY_MTLS_KEY_STORE_PATH:}
+      key-store-password: ${POLICY_MTLS_KEY_STORE_PASSWORD:}
+      key-store-type: ${POLICY_MTLS_KEY_STORE_TYPE:PKCS12}
+      trust-store-path: ${POLICY_MTLS_TRUST_STORE_PATH:}
+      trust-store-password: ${POLICY_MTLS_TRUST_STORE_PASSWORD:}
+      trust-store-type: ${POLICY_MTLS_TRUST_STORE_TYPE:PKCS12}
+    profile-guard:
+      enforce-mtls-in-non-dev: ${POLICY_MTLS_ENFORCE_NON_DEV:true}
+      dev-profiles: ${POLICY_DEV_PROFILES:dev,local,test}
   # ABAC SpEL Condition Evaluation
   abac:
     spel:

--- a/src/test/java/org/mangala/gateway/policy/PolicyApiSecurityProfileGuardTest.java
+++ b/src/test/java/org/mangala/gateway/policy/PolicyApiSecurityProfileGuardTest.java
@@ -1,0 +1,72 @@
+package org.mangala.gateway.policy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PolicyApiSecurityProfileGuardTest {
+
+    @Test
+    void shouldFailWhenNonDevProfileAndMtlsDisabled() {
+        PolicyConfigProperties config = new PolicyConfigProperties();
+        config.getMtls().setEnabled(false);
+
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("prod");
+
+        PolicyApiSecurityProfileGuard guard = new PolicyApiSecurityProfileGuard(config, env);
+
+        assertThatThrownBy(() -> guard.run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("mTLS must be enabled");
+    }
+
+    @Test
+    void shouldFailWhenNonDevProfileAndMtlsEnabledButMissingStores() {
+        PolicyConfigProperties config = new PolicyConfigProperties();
+        config.getMtls().setEnabled(true);
+        config.getMtls().setKeyStorePath("/tmp/client.p12");
+        config.getMtls().setKeyStorePassword("secret");
+
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("staging");
+
+        PolicyApiSecurityProfileGuard guard = new PolicyApiSecurityProfileGuard(config, env);
+
+        assertThatThrownBy(() -> guard.run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("trust-store-path");
+    }
+
+    @Test
+    void shouldPassWhenDevProfileAndMtlsDisabled() {
+        PolicyConfigProperties config = new PolicyConfigProperties();
+        config.getMtls().setEnabled(false);
+
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("dev");
+
+        PolicyApiSecurityProfileGuard guard = new PolicyApiSecurityProfileGuard(config, env);
+
+        assertThatCode(() -> guard.run(null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassWhenNonDevProfileAndMtlsFullyConfigured() {
+        PolicyConfigProperties config = new PolicyConfigProperties();
+        config.getMtls().setEnabled(true);
+        config.getMtls().setKeyStorePath("/tmp/client.p12");
+        config.getMtls().setKeyStorePassword("secret");
+        config.getMtls().setTrustStorePath("/tmp/trust.p12");
+        config.getMtls().setTrustStorePassword("secret");
+
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("prod");
+
+        PolicyApiSecurityProfileGuard guard = new PolicyApiSecurityProfileGuard(config, env);
+
+        assertThatCode(() -> guard.run(null)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- harden gateway->auth internal policy API transport with mTLS support
- add fail-fast startup guard for non-dev profiles when mTLS is not fully configured
- document security posture and config contracts

## Changes
- Added `PolicyApiMtlsWebClientConfig` to build mTLS-enabled WebClient builder for policy API calls
- Added `PolicyApiSecurityProfileGuard` to enforce non-dev profile rules:
  - require `gateway.policy.mtls.enabled=true`
  - require key/trust store path + password
- Extended `PolicyConfigProperties` with:
  - `gateway.policy.mtls.*`
  - `gateway.policy.profile-guard.*`
- Updated `AuthPolicyApiClient` to use dedicated qualified builder for policy API transport
- Added env mappings in `application.yml`:
  - `POLICY_MTLS_ENABLED`
  - `POLICY_MTLS_KEY_STORE_PATH` / `POLICY_MTLS_KEY_STORE_PASSWORD` / `POLICY_MTLS_KEY_STORE_TYPE`
  - `POLICY_MTLS_TRUST_STORE_PATH` / `POLICY_MTLS_TRUST_STORE_PASSWORD` / `POLICY_MTLS_TRUST_STORE_TYPE`
  - `POLICY_MTLS_ENFORCE_NON_DEV` / `POLICY_DEV_PROFILES`
- Added `PolicyApiSecurityProfileGuardTest`
- Updated docs:
  - `README.md`
  - `docs/context-map.yaml`
  - `docs/adr/0004-policy-api-mtls-hardening-non-dev.md`

## Verification
- `mvn -q -Dtest=PolicyApiSecurityProfileGuardTest,AuthPolicyApiClientContractTest test`
- `mvn -q -Dtest=SecurityHeadersAutoConfigurationTest,SecurityHeadersFilterTest,Security401RegressionTest,AbacAuthorizationRegressionTest,AuthPolicyApiClientContractTest,PolicyApiSecurityProfileGuardTest test`
- `./scripts/check-context-sync.sh`

Closes #9